### PR TITLE
Fix internal link validation for fragment identifiers

### DIFF
--- a/internal/structure/links.go
+++ b/internal/structure/links.go
@@ -34,6 +34,11 @@ func CheckInternalLinks(dir string, body string) []validator.Result {
 		if strings.HasPrefix(link, "mailto:") || strings.HasPrefix(link, "#") {
 			continue
 		}
+		// Strip fragment identifier (e.g. "guide.md#heading" → "guide.md")
+		link, _, _ = strings.Cut(link, "#")
+		if link == "" {
+			continue
+		}
 		// Relative link — check file existence
 		resolved := filepath.Join(dir, link)
 		if _, err := os.Stat(resolved); os.IsNotExist(err) {

--- a/internal/structure/links_test.go
+++ b/internal/structure/links_test.go
@@ -49,6 +49,14 @@ func TestCheckInternalLinks(t *testing.T) {
 		}
 	})
 
+	t.Run("file link with fragment identifier", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "references/guide.md", "# Heading\ncontent")
+		body := "See [config](references/guide.md#heading)."
+		results := CheckInternalLinks(dir, body)
+		requireResult(t, results, validator.Pass, "internal link: references/guide.md (exists)")
+	})
+
 	t.Run("no links returns nil", func(t *testing.T) {
 		dir := t.TempDir()
 		body := "No links here."


### PR DESCRIPTION
## Summary

- Strip `#fragment` from relative links before `os.Stat` file check
- Links like `references/guide.md#heading` no longer rejected as broken
- Add test case for file links with fragment identifiers

Fixes dacharyc/skill-validator#7

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` — all green
- [ ] Verify against a skill with `file.md#heading` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)