### PR TITLE
feat: respect flat skill layouts

### DIFF
--- a/skillcheck/validator.go
+++ b/skillcheck/validator.go
@@ -64,17 +64,19 @@ func ReadSkillRaw(dir string) string {
 	return string(data)
 }
 
-// ReadReferencesMarkdownFiles reads all .md files from <dir>/references/ and returns
-// a map from filename to content. Returns nil if no references dir or no .md files
-// are found.
+// ReadReferencesMarkdownFiles reads all .md files from <dir>/references/ and
+// non-extraneous root .md files. Returns a map from filename to content, or nil
+// if no qualifying files are found. Root files that collide with a references/
+// filename are skipped (subdirectory takes precedence).
 func ReadReferencesMarkdownFiles(dir string) map[string]string {
+	files := make(map[string]string)
+
 	refsDir := filepath.Join(dir, "references")
 	entries, err := os.ReadDir(refsDir)
 	if err != nil {
-		return nil
+		entries = nil
 	}
 
-	files := make(map[string]string)
 	for _, entry := range entries {
 		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 			continue
@@ -87,6 +89,34 @@ func ReadReferencesMarkdownFiles(dir string) map[string]string {
 			continue
 		}
 		files[entry.Name()] = string(data)
+	}
+
+	// Scan root-level .md files that are not extraneous and not SKILL.md.
+	rootEntries, err := os.ReadDir(dir)
+	if err == nil {
+		for _, entry := range rootEntries {
+			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			if strings.EqualFold(entry.Name(), "SKILL.md") {
+				continue
+			}
+			if !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+				continue
+			}
+			if util.IsExtraneousFile(entry.Name()) {
+				continue
+			}
+			// Skip if a references/ file with the same name already exists.
+			if _, exists := files[entry.Name()]; exists {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			files[entry.Name()] = string(data)
+		}
 	}
 
 	if len(files) == 0 {

--- a/skillcheck/validator_test.go
+++ b/skillcheck/validator_test.go
@@ -118,6 +118,64 @@ func TestReadReferencesMarkdownFiles_OnlyNonMd(t *testing.T) {
 	}
 }
 
+func TestReadReferencesMarkdownFiles_RootMdIncluded(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "---\nname: test\n---\n")
+	if err := os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Guide"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := ReadReferencesMarkdownFiles(dir)
+	if files == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if files["guide.md"] != "# Guide" {
+		t.Errorf("guide.md content = %q, want %q", files["guide.md"], "# Guide")
+	}
+}
+
+func TestReadReferencesMarkdownFiles_RootCollisionSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "---\nname: test\n---\n")
+	refsDir := filepath.Join(dir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "guide.md"), []byte("# Refs Guide"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Root Guide"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := ReadReferencesMarkdownFiles(dir)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files["guide.md"] != "# Refs Guide" {
+		t.Errorf("guide.md content = %q, want refs version", files["guide.md"])
+	}
+}
+
+func TestReadReferencesMarkdownFiles_ExtraneousExcluded(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "---\nname: test\n---\n")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Readme"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "guide.md"), []byte("# Guide"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := ReadReferencesMarkdownFiles(dir)
+	if _, exists := files["README.md"]; exists {
+		t.Error("README.md should be excluded as extraneous")
+	}
+	if files["guide.md"] != "# Guide" {
+		t.Errorf("guide.md content = %q", files["guide.md"])
+	}
+}
+
 func TestAnalyzeReferences_WithFiles(t *testing.T) {
 	dir := t.TempDir()
 	refsDir := filepath.Join(dir, "references")

--- a/structure/checks.go
+++ b/structure/checks.go
@@ -17,24 +17,36 @@ var recognizedDirs = map[string]bool{
 	"assets":     true,
 }
 
-// Files commonly found in repos but not intended for agent consumption.
-// Per Anthropic best practices: "A skill should only contain essential files
-// that directly support its functionality."
-// See: github.com/anthropics/skills → skill-creator
-var knownExtraneousFiles = map[string]string{
-	"readme.md":             "README.md",
-	"readme":                "README",
-	"changelog.md":          "CHANGELOG.md",
-	"changelog":             "CHANGELOG",
-	"license":               "LICENSE",
-	"license.md":            "LICENSE.md",
-	"license.txt":           "LICENSE.txt",
-	"contributing.md":       "CONTRIBUTING.md",
-	"code_of_conduct.md":    "CODE_OF_CONDUCT.md",
-	"installation_guide.md": "INSTALLATION_GUIDE.md",
-	"quick_reference.md":    "QUICK_REFERENCE.md",
-	"makefile":              "Makefile",
-	".gitignore":            ".gitignore",
+// rootFileCategory classifies root-level files in a skill directory.
+type rootFileCategory int
+
+const (
+	categoryExtraneous rootFileCategory = iota
+	categoryReference
+	categoryScript
+	categoryAsset
+)
+
+// scriptExtensions lists file extensions that are script-equivalent.
+var scriptExtensions = map[string]bool{
+	".py": true, ".sh": true, ".bash": true, ".js": true, ".ts": true,
+	".jsx": true, ".tsx": true, ".rb": true, ".go": true, ".rs": true,
+	".pl": true, ".lua": true, ".php": true, ".r": true,
+}
+
+// classifyRootFile determines the category of a non-SKILL.md root file.
+func classifyRootFile(name string) rootFileCategory {
+	if util.IsExtraneousFile(name) {
+		return categoryExtraneous
+	}
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".md" {
+		return categoryReference
+	}
+	if scriptExtensions[ext] {
+		return categoryScript
+	}
+	return categoryAsset
 }
 
 // CheckStructure validates the directory layout of a skill package. It checks
@@ -59,6 +71,7 @@ func CheckStructure(dir string) []types.Result {
 		return results
 	}
 
+	supportFileCount := 0
 	for _, entry := range entries {
 		name := entry.Name()
 		if strings.HasPrefix(name, ".") {
@@ -66,7 +79,12 @@ func CheckStructure(dir string) []types.Result {
 		}
 		if !entry.IsDir() {
 			if name != "SKILL.md" {
-				results = append(results, extraneousFileResult(ctx, name))
+				cat := classifyRootFile(name)
+				if cat == categoryExtraneous {
+					results = append(results, extraneousFileResult(ctx, name))
+				} else {
+					supportFileCount++
+				}
 			}
 			continue
 		}
@@ -89,6 +107,13 @@ func CheckStructure(dir string) []types.Result {
 			}
 			results = append(results, ctx.Warn(msg))
 		}
+	}
+
+	if supportFileCount >= 5 {
+		results = append(results, ctx.Infof(
+			"%d support files at root — consider organizing them into references/, scripts/, and assets/ subdirectories",
+			supportFileCount,
+		))
 	}
 
 	// Check for deep nesting in recognized directories
@@ -116,18 +141,10 @@ func extraneousFileResult(ctx types.ResultContext, name string) types.Result {
 			name,
 		))
 	}
-	if _, known := knownExtraneousFiles[lower]; known {
-		return ctx.WarnFile(name, fmt.Sprintf(
-			"%s is not needed in a skill — agents may load it into their context window, "+
-				"taking space from your actual task (Anthropic best practices: skills should only "+
-				"contain files that directly support agent functionality)",
-			name,
-		))
-	}
 	return ctx.WarnFile(name, fmt.Sprintf(
-		"unexpected file at root: %s — if agents need this file, move it into "+
-			"references/ or assets/ as appropriate; otherwise remove it to avoid "+
-			"unnecessary context window usage",
+		"%s is not needed in a skill — agents may load it into their context window, "+
+			"taking space from your actual task (Anthropic best practices: skills should only "+
+			"contain files that directly support agent functionality)",
 		name,
 	))
 }

--- a/structure/checks_test.go
+++ b/structure/checks_test.go
@@ -145,14 +145,12 @@ func TestCheckStructure(t *testing.T) {
 		requireResultContaining(t, results, types.Warning, "LICENSE is not needed in a skill")
 	})
 
-	t.Run("unknown file at root", func(t *testing.T) {
+	t.Run("support file at root not warned", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "content")
 		writeFile(t, dir, "notes.txt", "some notes")
 		results := CheckStructure(dir)
-		requireResultContaining(t, results, types.Warning, "unexpected file at root: notes.txt")
-		requireResultContaining(t, results, types.Warning, "move it into references/ or assets/")
-		requireResultContaining(t, results, types.Warning, "otherwise remove it")
+		requireNoLevel(t, results, types.Warning)
 	})
 
 	t.Run("deep nesting", func(t *testing.T) {
@@ -175,6 +173,54 @@ func TestCheckStructure(t *testing.T) {
 		results := CheckStructure(dir)
 		requireResult(t, results, types.Pass, "SKILL.md found")
 		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("flat layout md file not warned", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "guide content")
+		results := CheckStructure(dir)
+		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("flat layout script file not warned", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "setup.py", "#!/usr/bin/env python3")
+		results := CheckStructure(dir)
+		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("flat layout asset file not warned", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "config.yaml", "key: value")
+		results := CheckStructure(dir)
+		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("5+ support files emits info hint", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "guide")
+		writeFile(t, dir, "setup.py", "setup")
+		writeFile(t, dir, "config.yaml", "config")
+		writeFile(t, dir, "helpers.sh", "helpers")
+		writeFile(t, dir, "data.json", "data")
+		results := CheckStructure(dir)
+		requireResultContaining(t, results, types.Info, "5 support files at root")
+		requireResultContaining(t, results, types.Info, "consider organizing")
+	})
+
+	t.Run("4 support files no hint", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "guide")
+		writeFile(t, dir, "setup.py", "setup")
+		writeFile(t, dir, "config.yaml", "config")
+		writeFile(t, dir, "helpers.sh", "helpers")
+		results := CheckStructure(dir)
+		requireNoLevel(t, results, types.Info)
 	})
 
 	t.Run("hidden dirs inside recognized dirs are skipped", func(t *testing.T) {

--- a/structure/markdown.go
+++ b/structure/markdown.go
@@ -19,6 +19,29 @@ func CheckMarkdown(dir, body string) []types.Result {
 			"SKILL.md has an unclosed code fence starting at line %d — this may cause agents to misinterpret everything after it as code", line))
 	}
 
+	// Check root-level .md files (reference-equivalent).
+	if rootEntries, err := os.ReadDir(dir); err == nil {
+		for _, entry := range rootEntries {
+			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			if strings.EqualFold(entry.Name(), "SKILL.md") {
+				continue
+			}
+			if classifyRootFile(entry.Name()) != categoryReference {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			if line, ok := FindUnclosedFence(string(data)); ok {
+				results = append(results, ctx.ErrorAtLinef(entry.Name(), line,
+					"%s has an unclosed code fence starting at line %d — this may cause agents to misinterpret everything after it as code", entry.Name(), line))
+			}
+		}
+	}
+
 	// Check .md files in references/
 	refsDir := filepath.Join(dir, "references")
 	entries, err := os.ReadDir(refsDir)

--- a/structure/markdown_test.go
+++ b/structure/markdown_test.go
@@ -169,4 +169,19 @@ func TestCheckMarkdown(t *testing.T) {
 		results := CheckMarkdown(dir, "Clean body.")
 		requireNoLevel(t, results, types.Error)
 	})
+
+	t.Run("unclosed fence in root md file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "guide.md", "# Guide\n```\nunclosed fence")
+		results := CheckMarkdown(dir, "Clean body.")
+		requireResultContaining(t, results, types.Error, "guide.md has an unclosed code fence")
+		requireResultContaining(t, results, types.Error, "line 2")
+	})
+
+	t.Run("root extraneous md not checked for fences", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "README.md", "```unclosed")
+		results := CheckMarkdown(dir, "Clean body.")
+		requireNoLevel(t, results, types.Error)
+	})
 }

--- a/structure/orphans.go
+++ b/structure/orphans.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/agent-ecosystem/skill-validator/types"
+	"github.com/agent-ecosystem/skill-validator/util"
 )
 
 // orderedRecognizedDirs lists the recognized subdirectories in a stable order
@@ -82,7 +83,10 @@ func CheckOrphanFiles(dir, body string) []types.Result {
 			if reached[relPath] {
 				continue
 			}
+			isRootFile := !strings.Contains(relPath, string(filepath.Separator))
 			if containsReference(item.text, sourceDir, relPath) {
+				markReached(relPath, item.source, dir, &queue, reached, reachedFrom, inventory)
+			} else if isRootFile && containsReferenceCaseInsensitive(lowerText, relPath) {
 				markReached(relPath, item.source, dir, &queue, reached, reachedFrom, inventory)
 			} else if isPython && pythonImportReaches(item.text, item.source, relPath) {
 				// Python import resolution takes priority over the extensionless
@@ -122,33 +126,47 @@ func CheckOrphanFiles(dir, body string) []types.Result {
 		if len(dirFiles) == 0 {
 			continue
 		}
+		results = append(results, reportOrphans(ctx, dirFiles, reached, reachedFrom, missingExtension,
+			fmt.Sprintf("all files in %s/ are referenced", d))...)
+	}
 
-		hasOrphans := false
-		for _, relPath := range dirFiles {
-			if !reached[relPath] {
-				hasOrphans = true
-				results = append(results, ctx.WarnFile(relPath,
-					fmt.Sprintf("potentially unreferenced file: %s — agents may not discover this file without an explicit reference in SKILL.md or a referenced file", relPath)))
-			} else if missingExtension[relPath] {
-				ext := filepath.Ext(relPath)
-				noExt := strings.TrimSuffix(relPath, ext)
-				results = append(results, ctx.WarnFile(relPath,
-					fmt.Sprintf("file %s is referenced without its extension (as %s in %s) — include the %s extension so agents can reliably locate the file", relPath, noExt, reachedFrom[relPath], ext)))
-			}
-		}
-
-		if !hasOrphans {
-			results = append(results, ctx.Passf("all files in %s/ are referenced", d))
-		}
+	// Report root-level support file orphans.
+	rootSupport := rootInventoryFiles(inventory)
+	if len(rootSupport) > 0 {
+		results = append(results, reportOrphans(ctx, rootSupport, reached, reachedFrom, missingExtension,
+			"all root support files are referenced")...)
 	}
 
 	return results
 }
 
-// rootTextFiles returns the names of text files in the skill root directory,
-// excluding SKILL.md. These files aren't tracked as inventory (we don't warn
-// about them being orphaned), but they participate in the BFS as intermediaries
-// that can bridge SKILL.md to files in recognized directories.
+// reportOrphans generates orphan/missing-extension/pass results for a group of files.
+func reportOrphans(ctx types.ResultContext, files []string, reached map[string]bool, reachedFrom map[string]string, missingExtension map[string]bool, passMsg string) []types.Result {
+	var results []types.Result
+	hasOrphans := false
+	for _, relPath := range files {
+		if !reached[relPath] {
+			hasOrphans = true
+			results = append(results, ctx.WarnFile(relPath,
+				fmt.Sprintf("potentially unreferenced file: %s — agents may not discover this file without an explicit reference in SKILL.md or a referenced file", relPath)))
+		} else if missingExtension[relPath] {
+			ext := filepath.Ext(relPath)
+			noExt := strings.TrimSuffix(relPath, ext)
+			results = append(results, ctx.WarnFile(relPath,
+				fmt.Sprintf("file %s is referenced without its extension (as %s in %s) — include the %s extension so agents can reliably locate the file", relPath, noExt, reachedFrom[relPath], ext)))
+		}
+	}
+	if !hasOrphans {
+		results = append(results, ctx.Pass(passMsg))
+	}
+	return results
+}
+
+// rootTextFiles returns the names of extraneous text files in the skill root
+// directory. These files act as intermediaries in the BFS — they can bridge
+// SKILL.md to inventoried files — but are not themselves inventoried. Root
+// support files (references, scripts, assets) are now in inventory and don't
+// need to be returned here.
 func rootTextFiles(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -163,14 +181,15 @@ func rootTextFiles(dir string) []string {
 		if strings.EqualFold(name, "SKILL.md") {
 			continue
 		}
-		if isTextFile(name) {
+		if util.IsExtraneousFile(name) && isTextFile(name) {
 			files = append(files, name)
 		}
 	}
 	return files
 }
 
-// inventoryFiles collects relative paths for all files under recognized directories.
+// inventoryFiles collects relative paths for all files under recognized
+// directories, plus root-level support files (non-extraneous, non-SKILL.md).
 func inventoryFiles(dir string) []string {
 	var files []string
 	for _, d := range orderedRecognizedDirs {
@@ -197,6 +216,25 @@ func inventoryFiles(dir string) []string {
 			continue
 		}
 	}
+
+	// Collect root-level support files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return files
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if strings.EqualFold(entry.Name(), "SKILL.md") {
+			continue
+		}
+		if classifyRootFile(entry.Name()) == categoryExtraneous {
+			continue
+		}
+		files = append(files, entry.Name())
+	}
+
 	return files
 }
 
@@ -345,6 +383,25 @@ func pythonPackageInits(text, source, dir string) []string {
 		}
 	}
 	return inits
+}
+
+// containsReferenceCaseInsensitive checks whether lowerText (already lowered)
+// contains the lowercase form of relPath. Used for root-level support files
+// where skill authors commonly use different casing.
+func containsReferenceCaseInsensitive(lowerText, relPath string) bool {
+	return strings.Contains(lowerText, strings.ToLower(relPath))
+}
+
+// rootInventoryFiles returns inventory entries that have no path separator
+// (i.e., root-level files).
+func rootInventoryFiles(inventory []string) []string {
+	var out []string
+	for _, f := range inventory {
+		if !strings.Contains(f, string(filepath.Separator)) {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // isTextFile checks whether the file extension indicates a scannable text file.

--- a/structure/orphans_test.go
+++ b/structure/orphans_test.go
@@ -301,6 +301,62 @@ func TestCheckOrphanFiles(t *testing.T) {
 		requireResultContaining(t, results, types.Warning, "potentially unreferenced file: scripts/validators/extra.py")
 	})
 
+	t.Run("root support file referenced passes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "guide.md", "guide content")
+		writeFile(t, dir, "setup.py", "#!/usr/bin/env python3")
+
+		body := "Read guide.md and run setup.py to configure."
+		results := CheckOrphanFiles(dir, body)
+
+		requireResult(t, results, types.Pass, "all root support files are referenced")
+		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("root support file unreferenced is orphan", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "guide.md", "guide content")
+		writeFile(t, dir, "unused.py", "#!/usr/bin/env python3")
+
+		body := "Read guide.md for details."
+		results := CheckOrphanFiles(dir, body)
+
+		requireResultContaining(t, results, types.Warning, "potentially unreferenced file: unused.py")
+	})
+
+	t.Run("root file bridges to scripts dir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "guide.md", "Run scripts/deploy.sh to deploy.")
+		writeFile(t, dir, "scripts/deploy.sh", "#!/bin/bash")
+
+		body := "Read guide.md for deployment instructions."
+		results := CheckOrphanFiles(dir, body)
+
+		requireNoResultContaining(t, results, types.Warning, "scripts/deploy.sh")
+		requireResult(t, results, types.Pass, "all files in scripts/ are referenced")
+	})
+
+	t.Run("extraneous file not inventoried as root support", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "README.md", "readme content")
+
+		body := "No references."
+		results := CheckOrphanFiles(dir, body)
+
+		// README.md is extraneous, not inventoried — no orphan warning
+		requireNoResultContaining(t, results, types.Warning, "README.md")
+	})
+
+	t.Run("root support file case-insensitive match", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "Guide.md", "guide content")
+
+		body := "Read guide.md for details."
+		results := CheckOrphanFiles(dir, body)
+
+		requireResult(t, results, types.Pass, "all root support files are referenced")
+	})
+
 	t.Run("multiple orphans across directories", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "references/unused1.md", "content")

--- a/structure/tokens.go
+++ b/structure/tokens.go
@@ -58,12 +58,14 @@ func CheckTokens(dir, body string) ([]types.Result, []types.TokenCount, []types.
 
 	// Count tokens for files in references/
 	refTotal := 0
+	refsNames := make(map[string]bool) // track names to deduplicate against root .md files
 	refsDir := filepath.Join(dir, "references")
 	if entries, err := os.ReadDir(refsDir); err == nil {
 		for _, entry := range entries {
 			if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 				continue
 			}
+			refsNames[strings.ToLower(entry.Name())] = true
 			path := filepath.Join(refsDir, entry.Name())
 			data, err := os.ReadFile(path)
 			if err != nil {
@@ -79,21 +81,46 @@ func CheckTokens(dir, body string) ([]types.Result, []types.TokenCount, []types.
 				Tokens: fileTokens,
 			})
 			refTotal += fileTokens
+			results = append(results, checkRefFileLimit(ctx, relPath, fileTokens)...)
+		}
+	}
 
-			// Per-file limits
-			if fileTokens > refFileHardLimit {
-				results = append(results, ctx.ErrorFilef(relPath,
-					"%s is %d tokens — this will consume 12-20%% of a typical context window "+
-						"and meaningfully degrade agent performance; split into smaller focused files",
-					relPath, fileTokens,
-				))
-			} else if fileTokens > refFileSoftLimit {
-				results = append(results, ctx.WarnFilef(relPath,
-					"%s is %d tokens — consider splitting into smaller focused files "+
-						"so agents load only what they need",
-					relPath, fileTokens,
-				))
+	// Count root-level support files: .md as reference tokens, text assets as asset tokens.
+	// Skip root .md files that collide with a references/ file (subdirectory takes precedence).
+	rootEntries, _ := os.ReadDir(dir)
+	for _, entry := range rootEntries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if strings.EqualFold(entry.Name(), "SKILL.md") {
+			continue
+		}
+		cat := classifyRootFile(entry.Name())
+		if cat == categoryReference {
+			if refsNames[strings.ToLower(entry.Name())] {
+				continue
 			}
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				results = append(results, ctx.WarnFilef(entry.Name(), "could not read %s: %v", entry.Name(), err))
+				continue
+			}
+			tokens, _, _ := enc.Encode(string(data))
+			fileTokens := len(tokens)
+			counts = append(counts, types.TokenCount{File: entry.Name(), Tokens: fileTokens})
+			refTotal += fileTokens
+			results = append(results, checkRefFileLimit(ctx, entry.Name(), fileTokens)...)
+		} else if cat == categoryAsset {
+			ext := strings.ToLower(filepath.Ext(entry.Name()))
+			if !textAssetExtensions[ext] {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			tokens, _, _ := enc.Encode(string(data))
+			counts = append(counts, types.TokenCount{File: entry.Name(), Tokens: len(tokens)})
 		}
 	}
 
@@ -247,6 +274,10 @@ func countOtherFiles(dir string, enc tokenizer.Codec) []types.TokenCount {
 			if binaryExtensions[strings.ToLower(filepath.Ext(name))] {
 				continue
 			}
+			// Skip root support files — they're counted as references/assets.
+			if classifyRootFile(name) != categoryExtraneous {
+				continue
+			}
 			data, err := os.ReadFile(filepath.Join(dir, name))
 			if err != nil {
 				continue
@@ -257,6 +288,26 @@ func countOtherFiles(dir string, enc tokenizer.Codec) []types.TokenCount {
 	}
 
 	return counts
+}
+
+// checkRefFileLimit returns warning/error results if a reference file exceeds
+// per-file token thresholds.
+func checkRefFileLimit(ctx types.ResultContext, relPath string, fileTokens int) []types.Result {
+	if fileTokens > refFileHardLimit {
+		return []types.Result{ctx.ErrorFilef(relPath,
+			"%s is %d tokens — this will consume 12-20%% of a typical context window "+
+				"and meaningfully degrade agent performance; split into smaller focused files",
+			relPath, fileTokens,
+		)}
+	}
+	if fileTokens > refFileSoftLimit {
+		return []types.Result{ctx.WarnFilef(relPath,
+			"%s is %d tokens — consider splitting into smaller focused files "+
+				"so agents load only what they need",
+			relPath, fileTokens,
+		)}
+	}
+	return nil
 }
 
 func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec) []types.TokenCount {

--- a/structure/tokens_test.go
+++ b/structure/tokens_test.go
@@ -104,6 +104,114 @@ func TestCheckTokens(t *testing.T) {
 	})
 }
 
+func TestCheckTokens_RootFlatLayout(t *testing.T) {
+	t.Run("root md counted as reference tokens", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "# Guide\n\nSome reference content.")
+		_, counts, otherCounts := CheckTokens(dir, "body")
+		// body + guide.md = 2
+		if len(counts) != 2 {
+			t.Fatalf("expected 2 token counts, got %d", len(counts))
+		}
+		if counts[1].File != "guide.md" {
+			t.Errorf("expected guide.md, got %s", counts[1].File)
+		}
+		if counts[1].Tokens <= 0 {
+			t.Errorf("expected positive tokens for guide.md")
+		}
+		if len(otherCounts) != 0 {
+			t.Errorf("expected 0 other counts, got %d", len(otherCounts))
+		}
+	})
+
+	t.Run("root md aggregated with references dir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "Root guide content.")
+		writeFile(t, dir, "references/api.md", "API docs.")
+		_, counts, _ := CheckTokens(dir, "body")
+		// body + references/api.md + guide.md = 3
+		if len(counts) != 3 {
+			t.Fatalf("expected 3 token counts, got %d", len(counts))
+		}
+		files := map[string]bool{}
+		for _, c := range counts {
+			files[c.File] = true
+		}
+		if !files["guide.md"] {
+			t.Error("expected guide.md in counts")
+		}
+		if !files["references/api.md"] {
+			t.Error("expected references/api.md in counts")
+		}
+	})
+
+	t.Run("root md per-file limits apply", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "big-guide.md", generateContent(11_000))
+		results, _, _ := CheckTokens(dir, "body")
+		requireResultContaining(t, results, types.Warning, "big-guide.md")
+		requireResultContaining(t, results, types.Warning, "consider splitting")
+	})
+
+	t.Run("root script not token counted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "setup.py", "print('hello')")
+		_, counts, otherCounts := CheckTokens(dir, "body")
+		if len(counts) != 1 {
+			t.Fatalf("expected 1 token count (body only), got %d", len(counts))
+		}
+		if len(otherCounts) != 0 {
+			t.Fatalf("expected 0 other counts, got %d", len(otherCounts))
+		}
+	})
+
+	t.Run("root asset text file in token counts", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "config.yaml", "key: value")
+		_, counts, _ := CheckTokens(dir, "body")
+		if len(counts) != 2 {
+			t.Fatalf("expected 2 token counts, got %d", len(counts))
+		}
+		if counts[1].File != "config.yaml" {
+			t.Errorf("expected config.yaml, got %s", counts[1].File)
+		}
+	})
+
+	t.Run("root md skipped when same name in references", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "references/guide.md", "Refs version.")
+		writeFile(t, dir, "guide.md", "Root version — should be skipped.")
+		_, counts, _ := CheckTokens(dir, "body")
+		// body + references/guide.md = 2 (root guide.md deduplicated)
+		if len(counts) != 2 {
+			t.Fatalf("expected 2 token counts (body + references/guide.md), got %d", len(counts))
+		}
+		for _, c := range counts {
+			if c.File == "guide.md" {
+				t.Error("root guide.md should be skipped when references/guide.md exists")
+			}
+		}
+	})
+
+	t.Run("root support files not in other counts", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "guide.md", "guide")
+		writeFile(t, dir, "setup.py", "setup")
+		writeFile(t, dir, "config.yaml", "config")
+		_, _, otherCounts := CheckTokens(dir, "body")
+		if len(otherCounts) != 0 {
+			t.Fatalf("expected 0 other counts, got %d", len(otherCounts))
+		}
+	})
+}
+
 // generateContent creates a string of approximately the target token count.
 // Uses repetitive sentences (~10 tokens each).
 func generateContent(approxTokens int) string {
@@ -172,11 +280,11 @@ func TestCheckTokens_AggregateRefLimits(t *testing.T) {
 }
 
 func TestCountOtherFiles(t *testing.T) {
-	t.Run("counts extra root files", func(t *testing.T) {
+	t.Run("counts extraneous root files", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "---\nname: test\n---\nbody")
 		writeFile(t, dir, "AGENTS.md", "Some agent content here.")
-		writeFile(t, dir, "metadata.json", `{"key": "value"}`)
+		writeFile(t, dir, "README.md", "Readme content.")
 		_, _, otherCounts := CheckTokens(dir, "body")
 		if len(otherCounts) != 2 {
 			t.Fatalf("expected 2 other counts, got %d", len(otherCounts))
@@ -191,8 +299,8 @@ func TestCountOtherFiles(t *testing.T) {
 		if !files["AGENTS.md"] {
 			t.Error("expected AGENTS.md in other counts")
 		}
-		if !files["metadata.json"] {
-			t.Error("expected metadata.json in other counts")
+		if !files["README.md"] {
+			t.Error("expected README.md in other counts")
 		}
 	})
 
@@ -222,13 +330,13 @@ func TestCountOtherFiles(t *testing.T) {
 		writeFile(t, dir, "SKILL.md", "content")
 		writeFile(t, dir, "image.png", "fake png data")
 		writeFile(t, dir, "archive.zip", "fake zip data")
-		writeFile(t, dir, "notes.txt", "text content")
+		writeFile(t, dir, "CHANGELOG.md", "text content")
 		_, _, otherCounts := CheckTokens(dir, "body")
 		if len(otherCounts) != 1 {
-			t.Fatalf("expected 1 other count (notes.txt only), got %d", len(otherCounts))
+			t.Fatalf("expected 1 other count (CHANGELOG.md only), got %d", len(otherCounts))
 		}
-		if otherCounts[0].File != "notes.txt" {
-			t.Errorf("expected notes.txt, got %s", otherCounts[0].File)
+		if otherCounts[0].File != "CHANGELOG.md" {
+			t.Errorf("expected CHANGELOG.md, got %s", otherCounts[0].File)
 		}
 	})
 
@@ -236,13 +344,13 @@ func TestCountOtherFiles(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "content")
 		writeFile(t, dir, ".hidden", "secret")
-		writeFile(t, dir, "visible.txt", "visible content")
+		writeFile(t, dir, "LICENSE", "visible content")
 		_, _, otherCounts := CheckTokens(dir, "body")
 		if len(otherCounts) != 1 {
 			t.Fatalf("expected 1 other count, got %d", len(otherCounts))
 		}
-		if otherCounts[0].File != "visible.txt" {
-			t.Errorf("expected visible.txt, got %s", otherCounts[0].File)
+		if otherCounts[0].File != "LICENSE" {
+			t.Errorf("expected LICENSE, got %s", otherCounts[0].File)
 		}
 	})
 
@@ -272,7 +380,8 @@ func TestCheckTokens_OtherFilesLimits(t *testing.T) {
 	t.Run("other files under soft limit", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "content")
-		writeFile(t, dir, "extra.md", generateContent(5_000))
+		// Use an unknown directory so files land in "other" counts.
+		writeFile(t, dir, "extras/small.md", generateContent(5_000))
 		results, _, _ := CheckTokens(dir, "body")
 		requireNoResultContaining(t, results, types.Warning, "non-standard files total")
 		requireNoResultContaining(t, results, types.Error, "non-standard files total")
@@ -281,8 +390,8 @@ func TestCheckTokens_OtherFilesLimits(t *testing.T) {
 	t.Run("other files exceed soft limit", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "content")
-		writeFile(t, dir, "extra1.md", generateContent(15_000))
-		writeFile(t, dir, "extra2.md", generateContent(15_000))
+		writeFile(t, dir, "extras/file1.md", generateContent(15_000))
+		writeFile(t, dir, "extras/file2.md", generateContent(15_000))
 		results, _, _ := CheckTokens(dir, "body")
 		requireResultContaining(t, results, types.Warning, "non-standard files total")
 		requireResultContaining(t, results, types.Warning, "could consume a significant portion")

--- a/structure/validate_test.go
+++ b/structure/validate_test.go
@@ -110,7 +110,8 @@ func TestValidate(t *testing.T) {
 	t.Run("no skill ratio error when other content is small", func(t *testing.T) {
 		dir := t.TempDir()
 		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n")
-		writeFile(t, dir, "extra.md", "A small extra file.")
+		// Use an extraneous file so it lands in "other" counts rather than standard counts.
+		writeFile(t, dir, "CHANGELOG.md", "A small changelog.")
 		report := Validate(dir, Options{})
 		requireNoResultContaining(t, report.Results, types.Error, "doesn't appear to be structured as a skill")
 	})
@@ -123,6 +124,35 @@ func TestValidate(t *testing.T) {
 			t.Errorf("expected 1 error, got %d", report.Errors)
 		}
 		requireResultContaining(t, report.Results, types.Error, "parsing frontmatter YAML")
+	})
+
+	t.Run("flat layout not penalized by skill ratio", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n")
+		writeFile(t, dir, "guide.md", "A reference guide.")
+		writeFile(t, dir, "setup.py", "#!/usr/bin/env python3")
+		writeFile(t, dir, "config.yaml", "key: value")
+		report := Validate(dir, Options{})
+		requireNoResultContaining(t, report.Results, types.Error, "doesn't appear to be structured as a skill")
+		if report.Errors != 0 {
+			t.Errorf("expected 0 errors, got %d", report.Errors)
+		}
+	})
+
+	t.Run("flat-skill fixture integration", func(t *testing.T) {
+		fixtureDir := "../testdata/flat-skill"
+		report := Validate(fixtureDir, Options{})
+		// Should only get README.md warning, no errors
+		if report.Errors != 0 {
+			t.Errorf("expected 0 errors, got %d", report.Errors)
+			for _, r := range report.Results {
+				if r.Level == types.Error {
+					t.Logf("  error: %s: %s", r.Category, r.Message)
+				}
+			}
+		}
+		// README.md should be warned
+		requireResultContaining(t, report.Results, types.Warning, "README.md is not needed in a skill")
 	})
 }
 

--- a/testdata/flat-skill/README.md
+++ b/testdata/flat-skill/README.md
@@ -1,0 +1,3 @@
+# Flat Skill
+
+This README should generate a warning since it's extraneous.

--- a/testdata/flat-skill/SKILL.md
+++ b/testdata/flat-skill/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: flat-skill
+description: A skill using flat layout with support files at root.
+---
+
+# Flat Skill
+
+This skill demonstrates a flat layout where support files live alongside SKILL.md.
+
+## Usage
+
+Read guide.md for detailed instructions. Run setup.py to configure the environment.
+
+The config.yaml file contains default settings.

--- a/testdata/flat-skill/config.yaml
+++ b/testdata/flat-skill/config.yaml
@@ -1,0 +1,5 @@
+name: flat-skill
+version: "1.0"
+settings:
+  debug: false
+  timeout: 30

--- a/testdata/flat-skill/guide.md
+++ b/testdata/flat-skill/guide.md
@@ -1,0 +1,9 @@
+# Guide
+
+This is a reference guide for the flat skill.
+
+## Steps
+
+1. Read this guide
+2. Run setup.py
+3. Check config.yaml

--- a/testdata/flat-skill/setup.py
+++ b/testdata/flat-skill/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Setup script for flat skill."""
+
+def configure():
+    print("Configuring flat skill environment")
+
+if __name__ == "__main__":
+    configure()

--- a/util/util.go
+++ b/util/util.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // --- Color constants for terminal output ---
@@ -74,6 +75,39 @@ func YSuffix(n int) string {
 // SkillNameFromDir derives a skill name from a directory path.
 func SkillNameFromDir(dir string) string {
 	return filepath.Base(dir)
+}
+
+// --- Extraneous file detection ---
+
+// knownExtraneousFiles maps lower-cased filenames to their canonical display
+// form. These files are commonly found in repos but not intended for agent
+// consumption. Per Anthropic best practices: "A skill should only contain
+// essential files that directly support its functionality."
+var knownExtraneousFiles = map[string]string{
+	"readme.md":             "README.md",
+	"readme":                "README",
+	"changelog.md":          "CHANGELOG.md",
+	"changelog":             "CHANGELOG",
+	"license":               "LICENSE",
+	"license.md":            "LICENSE.md",
+	"license.txt":           "LICENSE.txt",
+	"contributing.md":       "CONTRIBUTING.md",
+	"code_of_conduct.md":    "CODE_OF_CONDUCT.md",
+	"installation_guide.md": "INSTALLATION_GUIDE.md",
+	"quick_reference.md":    "QUICK_REFERENCE.md",
+	"makefile":              "Makefile",
+	".gitignore":            ".gitignore",
+}
+
+// IsExtraneousFile returns true if name is agents.md (case-insensitive)
+// or a known extraneous file.
+func IsExtraneousFile(name string) bool {
+	lower := strings.ToLower(name)
+	if lower == "agents.md" {
+		return true
+	}
+	_, known := knownExtraneousFiles[lower]
+	return known
 }
 
 // --- Map helpers ---


### PR DESCRIPTION
## Summary

- Root-level support files alongside SKILL.md now receive equivalent treatment to files in `references/`, `scripts/`, and `assets/` subdirectories
- Adds `classifyRootFile()` to categorize root files as reference (`.md`), script, asset, or extraneous
- Extracts shared `IsExtraneousFile()` helper to `util` package
- Token counting, orphan detection, markdown validation, and reference analysis all respect flat layouts
- Root `.md` files are deduplicated against `references/` (subdirectory takes precedence)

Closes #23

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New unit tests for classification, token counting, orphan detection, markdown fence checking, and reference reading
- [x] Integration test with `testdata/flat-skill/` fixture
- [x] `go vet`, `golangci-lint`, `gofumpt` all clean
- [x] Manual verification: `./skill-validator check testdata/flat-skill/` shows only README.md warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)