### PR TITLE
feat: recognize roles as a valid frontmatter field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Recognize `roles` as a valid frontmatter field. The field accepts a list of
+  strings and is used by skill registries to tag skills by audience or team role.
+  Previously, skills using `roles` received an "unrecognized field" warning.
+
 ## [1.2.1]
 
 ### Fixed

--- a/skill/skill.go
+++ b/skill/skill.go
@@ -22,6 +22,7 @@ type Frontmatter struct {
 	Compatibility string            `yaml:"compatibility"`
 	Metadata      map[string]string `yaml:"metadata"`
 	AllowedTools  AllowedTools      `yaml:"allowed-tools"`
+	Roles         []string          `yaml:"roles"`
 }
 
 // AllowedTools handles the type ambiguity in the allowed-tools field.
@@ -76,6 +77,7 @@ var knownFrontmatterFields = map[string]bool{
 	"compatibility": true,
 	"metadata":      true,
 	"allowed-tools": true,
+	"roles":         true,
 }
 
 // Load reads and parses a SKILL.md file from the given directory.

--- a/skill/skill_test.go
+++ b/skill/skill_test.go
@@ -282,3 +282,21 @@ func TestUnrecognizedFields(t *testing.T) {
 		t.Error("expected another in unrecognized fields")
 	}
 }
+
+func TestRolesFieldIsRecognized(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: test\ndescription: desc\nroles: [frontend, backend]\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fields := s.UnrecognizedFields(); len(fields) != 0 {
+		t.Errorf("roles should be recognized, got unrecognized: %v", fields)
+	}
+	if len(s.Frontmatter.Roles) != 2 {
+		t.Errorf("expected 2 roles, got %v", s.Frontmatter.Roles)
+	}
+}


### PR DESCRIPTION
Author notes:
Hi @dacharyc ! Thank you for skills-validator. I am keen to implement skills-validator into a CI job for our agent skills repo and to help with our efforts to review and perform quality checks on skill PRs. We've been seeing quite an influx on submitted skills and we're having discussion on assessing quality and testing for these skills that perform an array on engineering and non-engineering based tasks.

While running skills-validator with claude code, claude suggested adding a `roles` frontmatter field for the tool, and I wanted to see if this is viable for public adoption for other teams to use across our skills registry. A role in this case means a collection of tools, packages, and agent skills that we make available to engineer types e.g. a backend engineer that needs a bundle of skills can use skills with the `backend` role defined. 

There were skills yaml snippets that triggered an unrecognized field warning when I tried running skills-validator across our 100+ skills.

Open to feedback and discussions! This is also my first PR on an open source tool for agentic-based tools, so happy to get any additional tips on continued collaboration on these tools for agentic skills governance. Thank you.

Here's the AI-generated PR summary:

## Summary

Adds `roles` to the set of recognized SKILL.md frontmatter fields, both as a parsed struct field on `Frontmatter` and in `knownFrontmatterFields`.

## Motivation

The `roles` field is already in widespread use across skill registries — for example, it appears in over 100 published skills in at least one downstream registry. Currently, any skill using `roles` triggers a spurious `"unrecognized field: roles"` warning, even though the skill is otherwise well-formed.

The field accepts a list of strings and is used to tag skills by audience or team role (e.g. `[frontend, devops]`), enabling registries to filter or surface skills by persona.

## Changes

- `skill/skill.go` — add `Roles []string` to `Frontmatter` struct and add `"roles"` to `knownFrontmatterFields`
- `skill/skill_test.go` — add `TestRolesFieldIsRecognized` covering both the no-warning and parsed-value cases
- `CHANGELOG.md` — note under `[Unreleased]`

## Testing

`go test ./skill/...`

All existing tests pass; new test confirms `roles` is parsed correctly and produces no unrecognized-field warning.

##  Open question

Should `roles` be part of the formal agentskills.io formal spec?