### PR TITLE
refactor: deduplicate regex patterns into util/regex.go

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -52,10 +52,7 @@ var imperativeVerbs = map[string]bool{
 }
 
 var (
-	codeBlockPattern = regexp.MustCompile("(?s)```[\\w]*\\n(.*?)```")
-	codeLangPattern  = regexp.MustCompile("```(\\w+)")
-	codeBlockStrip   = regexp.MustCompile("(?s)```[\\w]*\\n.*?```")
-	inlineCodeStrip  = regexp.MustCompile("`[^`]+`")
+	codeLangPattern  = regexp.MustCompile("(?:```|~~~)(\\w+)")
 	sentenceSplitPat = regexp.MustCompile(`[.!?]\s+|[.!?]$|\n\n+`)
 	leadingFormatPat = regexp.MustCompile(`^[#*\->\s]+`)
 	sectionPattern   = regexp.MustCompile(`(?m)^#{2,}\s+`)
@@ -72,7 +69,7 @@ func Analyze(content string) *types.ContentReport {
 	wordCount := len(words)
 
 	// Code block analysis
-	codeBlocks := codeBlockPattern.FindAllStringSubmatch(content, -1)
+	codeBlocks := util.CodeBlockPattern.FindAllStringSubmatch(content, -1)
 	codeBlockCount := len(codeBlocks)
 	codeBlockWords := 0
 	for _, match := range codeBlocks {
@@ -141,9 +138,9 @@ func Analyze(content string) *types.ContentReport {
 
 func countSentences(text string) []string {
 	// Remove code blocks first
-	text = codeBlockStrip.ReplaceAllString(text, "")
+	text = util.CodeBlockStrip.ReplaceAllString(text, "")
 	// Remove inline code
-	text = inlineCodeStrip.ReplaceAllString(text, "")
+	text = util.InlineCodeStrip.ReplaceAllString(text, "")
 	// Split on sentence boundaries
 	parts := sentenceSplitPat.Split(text, -1)
 	var sentences []string

--- a/links/extract.go
+++ b/links/extract.go
@@ -6,6 +6,8 @@ package links
 import (
 	"regexp"
 	"strings"
+
+	"github.com/agent-ecosystem/skill-validator/util"
 )
 
 var (
@@ -13,10 +15,6 @@ var (
 	mdLinkPattern = regexp.MustCompile(`\[([^\]]*)\]\(([^)]+)\)`)
 	// bareURLPattern matches bare URLs starting with http:// or https://.
 	bareURLPattern = regexp.MustCompile("(?:^|\\s)(https?://[^\\s<>\\)`]+)")
-	// codeBlockStrip removes fenced code blocks before link extraction.
-	codeBlockStrip = regexp.MustCompile("(?s)(?:```|~~~)[\\w]*\\n.*?(?:```|~~~)")
-	// inlineCodeStrip removes inline code spans before link extraction.
-	inlineCodeStrip = regexp.MustCompile("`[^`]+`")
 )
 
 // ExtractLinks extracts all unique links from a markdown body.
@@ -25,8 +23,8 @@ func ExtractLinks(body string) []string {
 	var links []string
 
 	// Strip code fences and inline code spans so URLs in code are not extracted.
-	cleaned := codeBlockStrip.ReplaceAllString(body, "")
-	cleaned = inlineCodeStrip.ReplaceAllString(cleaned, "")
+	cleaned := util.CodeBlockStrip.ReplaceAllString(body, "")
+	cleaned = util.InlineCodeStrip.ReplaceAllString(cleaned, "")
 
 	// Markdown links
 	for _, match := range mdLinkPattern.FindAllStringSubmatch(cleaned, -1) {

--- a/util/regex.go
+++ b/util/regex.go
@@ -1,0 +1,12 @@
+package util
+
+import "regexp"
+
+// CodeBlockStrip removes fenced code blocks (backtick and tilde) from markdown.
+var CodeBlockStrip = regexp.MustCompile("(?s)(?:```|~~~)[\\w]*\\n.*?(?:```|~~~)")
+
+// InlineCodeStrip removes inline code spans from markdown.
+var InlineCodeStrip = regexp.MustCompile("`[^`]+`")
+
+// CodeBlockPattern extracts fenced code block bodies (capture group 1) from markdown.
+var CodeBlockPattern = regexp.MustCompile("(?s)(?:```|~~~)[\\w]*\\n(.*?)(?:```|~~~)")

--- a/util/regex_test.go
+++ b/util/regex_test.go
@@ -1,0 +1,77 @@
+package util
+
+import "testing"
+
+func TestCodeBlockStrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "backtick fence",
+			input: "before\n```go\ncode here\n```\nafter",
+			want:  "before\n\nafter",
+		},
+		{
+			name:  "tilde fence",
+			input: "before\n~~~python\ncode here\n~~~\nafter",
+			want:  "before\n\nafter",
+		},
+		{
+			name:  "no fence",
+			input: "just plain text",
+			want:  "just plain text",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CodeBlockStrip.ReplaceAllString(tt.input, "")
+			if got != tt.want {
+				t.Errorf("CodeBlockStrip:\n  got:  %q\n  want: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInlineCodeStrip(t *testing.T) {
+	input := "use `foo` and `bar` here"
+	want := "use  and  here"
+	got := InlineCodeStrip.ReplaceAllString(input, "")
+	if got != want {
+		t.Errorf("InlineCodeStrip:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestCodeBlockPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantN    int
+		wantBody string
+	}{
+		{
+			name:     "backtick fence",
+			input:    "```go\nfmt.Println()\n```",
+			wantN:    1,
+			wantBody: "fmt.Println()\n",
+		},
+		{
+			name:     "tilde fence",
+			input:    "~~~python\nprint('hi')\n~~~",
+			wantN:    1,
+			wantBody: "print('hi')\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := CodeBlockPattern.FindAllStringSubmatch(tt.input, -1)
+			if len(matches) != tt.wantN {
+				t.Fatalf("expected %d matches, got %d", tt.wantN, len(matches))
+			}
+			if matches[0][1] != tt.wantBody {
+				t.Errorf("body:\n  got:  %q\n  want: %q", matches[0][1], tt.wantBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract shared `CodeBlockStrip`, `InlineCodeStrip`, and `CodeBlockPattern` regexes into `util/regex.go`
- Fixes tilde-fence stripping in content analysis
- Adds comprehensive tests for the shared patterns

## Test plan

- [x] New tests for backtick and tilde fence patterns
- [x] Existing tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)