### PR TITLE
Recognize evals/ as a valid skill directory

### DIFF
--- a/structure/checks.go
+++ b/structure/checks.go
@@ -17,6 +17,15 @@ var recognizedDirs = map[string]bool{
 	"assets":     true,
 }
 
+// recognizedDevDirs lists development directories that are recognized but
+// not part of the bundled skill resources. These directories are exempt from
+// the deep-nesting check because subdirectories are part of their expected
+// structure (e.g. evals/files/).
+// See: agentskills.io/skill-creation/evaluating-skills
+var recognizedDevDirs = map[string]bool{
+	"evals": true,
+}
+
 // Files commonly found in repos but not intended for agent consumption.
 // Per Anthropic best practices: "A skill should only contain essential files
 // that directly support its functionality."
@@ -70,7 +79,7 @@ func CheckStructure(dir string, opts Options) []types.Result {
 			}
 			continue
 		}
-		if !recognizedDirs[name] {
+		if !recognizedDirs[name] && !recognizedDevDirs[name] {
 			msg := fmt.Sprintf("unknown directory: %s/", name)
 			if subEntries, err := os.ReadDir(filepath.Join(dir, name)); err == nil {
 				fileCount := 0

--- a/structure/checks_test.go
+++ b/structure/checks_test.go
@@ -36,6 +36,19 @@ func TestCheckStructure(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
 			t.Fatal(err)
 		}
+		if err := os.MkdirAll(filepath.Join(dir, "evals"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		results := CheckStructure(dir, Options{})
+		requireResult(t, results, types.Pass, "SKILL.md found")
+		requireNoLevel(t, results, types.Warning)
+	})
+
+	t.Run("evals directory with files produces no warning", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "evals/evals.json", `{"skill_name":"test","evals":[]}`)
+		writeFile(t, dir, "evals/files/sample.csv", "a,b,c")
 		results := CheckStructure(dir, Options{})
 		requireResult(t, results, types.Pass, "SKILL.md found")
 		requireNoLevel(t, results, types.Warning)


### PR DESCRIPTION
## Summary

- Add `evals/` as a recognized development directory so the validator no longer warns about it
- Unlike bundled resource directories (`scripts/`, `references/`, `assets/`), `evals/` is exempt from the deep-nesting check because subdirectories like `evals/files/` are part of its expected structure
- The [evaluating-skills guide](https://agentskills.io/skill-creation/evaluating-skills) recommends storing `evals/evals.json` and `evals/files/` inside the skill directory

## Test plan

- [x] Existing test: `evals` added to "recognized directories" test case — no warnings produced
- [x] New test: `evals/evals.json` + `evals/files/sample.csv` produces no warnings (covers deep nesting exemption)
- [x] Full test suite passes (613 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)