### PR TITLE
feat(structure): allow deep nesting at selected paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Spec compliance is table stakes. `skill-validator` goes further: it checks that 
   - [Structure validation](#structure-validation-validate-structure)
     - [Flat skill layouts](#flat-skill-layouts)
     - [Allowing non-standard directories](#allowing-non-standard-directories)
+    - [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)
   - [Link validation](#link-validation-validate-links)
   - [Content analysis](#content-analysis-analyze-content)
   - [Contamination analysis](#contamination-analysis-analyze-contamination)
@@ -188,6 +189,7 @@ skill-validator validate structure --strict <path>
 skill-validator validate structure --allow-extra-frontmatter <path>
 skill-validator validate structure --allow-flat-layouts <path>
 skill-validator validate structure --allow-dirs=evals,testing <path>
+skill-validator validate structure --allow-nested-paths=assets/components <path>
 ```
 
 Checks spec compliance: directory structure, frontmatter fields, token limits, skill ratio, code fence integrity, internal link validity, and orphan file detection.
@@ -199,6 +201,7 @@ Checks spec compliance: directory structure, frontmatter fields, token limits, s
 | `--allow-extra-frontmatter` | Suppress warnings for non-spec frontmatter fields (e.g. `user-invokable`). Standard fields are still fully validated |
 | `--allow-flat-layouts` | Allow files at the skill root without warnings (see [Flat skill layouts](#flat-skill-layouts)) |
 | `--allow-dirs=evals,testing` | Accept specific non-standard directories without warnings (see [Allowing non-standard directories](#allowing-non-standard-directories)) |
+| `--allow-nested-paths=assets/components` | Allow deep nesting only within specific skill-relative paths (see [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)) |
 
 ```
 Validating skill: my-skill/
@@ -296,6 +299,7 @@ skill-validator check --strict <path>
 skill-validator check --allow-extra-frontmatter <path>
 skill-validator check --allow-flat-layouts <path>
 skill-validator check --allow-dirs=evals,testing <path>
+skill-validator check --allow-nested-paths=assets/components <path>
 ```
 
 Runs all checks (structure + links + content + contamination).
@@ -310,6 +314,7 @@ Runs all checks (structure + links + content + contamination).
 | `--allow-extra-frontmatter` | Suppress warnings for non-spec frontmatter fields |
 | `--allow-flat-layouts` | Allow files at the skill root without warnings (see [Flat skill layouts](#flat-skill-layouts)) |
 | `--allow-dirs=evals,testing` | Accept specific non-standard directories without warnings (see [Allowing non-standard directories](#allowing-non-standard-directories)) |
+| `--allow-nested-paths=assets/components` | Allow deep nesting only within specific skill-relative paths (see [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)) |
 
 Valid check groups: `structure`, `links`, `content`, `contamination`.
 
@@ -766,6 +771,19 @@ Directories not in the allow list still produce the standard warning with file c
 
 > [!NOTE]
 > Allowing a directory suppresses validator warnings but does not change how agent platforms handle the directory. Files in non-standard directories may not be discovered during skill activation, or may load into agent context unexpectedly. If you're distributing skills across platforms, consider whether those files belong in `references/` or `assets/` instead.
+
+**Allowing nesting at specific paths**
+
+Some recognized directories intentionally contain self-contained bundles. For example, `assets/components/<name>/` may group templates and supporting files by component. Use `--allow-nested-paths` to suppress only the deep-nesting warning for an explicitly selected subtree:
+
+```
+skill-validator validate structure --allow-nested-paths=assets/components my-skill/
+skill-validator check --allow-nested-paths=assets/components,assets/themes my-skill/
+```
+
+Paths are relative to the skill root. The flag accepts a comma-separated list or can be repeated, normalizes `/` and `\` separators, and rejects absolute paths or paths that escape the skill root. Matching observes path boundaries: allowing `assets/components` does not allow `assets/components-extra`.
+
+This option affects only deep-nesting warnings. Structure checks outside the selected subtree and all frontmatter, orphan, token, Markdown, and link checks continue unchanged. When a nesting warning is suppressed, the report includes an informational result identifying the allowed path.
 
 ### Link validation (`validate links`)
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,6 +21,7 @@ var (
 	checkAllowExtraFrontmatter bool
 	checkAllowFlatLayouts      bool
 	checkAllowDirs             []string
+	checkAllowNestedPaths      []string
 )
 
 var checkCmd = &cobra.Command{
@@ -44,6 +45,8 @@ func init() {
 		"allow files at the skill root without warnings and treat them as standard content for token counting")
 	checkCmd.Flags().StringSliceVar(&checkAllowDirs, "allow-dirs", nil,
 		"comma-separated list of directory names to accept without warnings (e.g. --allow-dirs=evals,testing)")
+	checkCmd.Flags().StringSliceVar(&checkAllowNestedPaths, "allow-nested-paths", nil,
+		"comma-separated skill-relative paths where deep nesting is allowed (e.g. --allow-nested-paths=assets/components)")
 	rootCmd.AddCommand(checkCmd)
 }
 
@@ -57,6 +60,11 @@ var validGroups = map[orchestrate.CheckGroup]bool{
 func runCheck(cmd *cobra.Command, args []string) error {
 	if len(checkOnly) > 0 && len(checkSkip) > 0 {
 		return fmt.Errorf("--only and --skip are mutually exclusive")
+	}
+
+	allowNestedPaths, err := structure.NormalizeRelativePaths(checkAllowNestedPaths)
+	if err != nil {
+		return fmt.Errorf("invalid --allow-nested-paths: %w", err)
 	}
 
 	enabled, err := resolveCheckGroups(checkOnly, checkSkip)
@@ -76,6 +84,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 			AllowExtraFrontmatter: checkAllowExtraFrontmatter,
 			AllowFlatLayouts:      checkAllowFlatLayouts,
 			AllowDirs:             checkAllowDirs,
+			AllowNestedPaths:      allowNestedPaths,
 		},
 	}
 	eopts := exitOpts{strict: strictCheck}

--- a/cmd/exitcode_integration_test.go
+++ b/cmd/exitcode_integration_test.go
@@ -172,6 +172,20 @@ func TestSliceFlags(t *testing.T) {
 			wantStdout: "unknown directory: testing/",
 			noStdout:   "unknown directory: evals/",
 		},
+		{
+			name:       "check allow-nested-paths suppresses exact path only",
+			args:       []string{"check", "--only=structure", "--skip-orphans", "--allow-nested-paths=assets/components", fixture(t, "nested-paths-skill")},
+			wantCode:   2,
+			wantStdout: "deep nesting detected: assets/components-extra/",
+			noStdout:   "deep nesting detected: assets/components/",
+		},
+		{
+			name:       "validate structure allow-nested-paths accepts Windows separators",
+			args:       []string{"validate", "structure", "--skip-orphans", `--allow-nested-paths=assets\components,assets\components-extra`, fixture(t, "nested-paths-skill")},
+			wantCode:   0,
+			wantStdout: "deep nesting allowed: assets/components/",
+			noStdout:   "deep nesting detected:",
+		},
 	}
 
 	for _, tt := range tests {
@@ -191,6 +205,52 @@ func TestSliceFlags(t *testing.T) {
 				if strings.Contains(string(out), tt.noStdout) {
 					t.Errorf("expected output NOT to contain %q, got:\n%s", tt.noStdout, out)
 				}
+			}
+		})
+	}
+}
+
+func TestAllowNestedPathsInvalidPath(t *testing.T) {
+	bin := buildBinary(t)
+
+	for _, args := range [][]string{
+		{"validate", "structure", "--allow-nested-paths=/assets/components", fixture(t, "valid-skill")},
+		{"check", "--allow-nested-paths=../components", fixture(t, "valid-skill")},
+	} {
+		cmd := exec.Command(bin, args...)
+		out, _ := cmd.CombinedOutput()
+		if got := cmd.ProcessState.ExitCode(); got != 3 {
+			t.Errorf("exit code = %d, want 3 (args: %v)\noutput: %s", got, args, out)
+		}
+		if !strings.Contains(string(out), "invalid --allow-nested-paths") {
+			t.Errorf("expected invalid path error, got:\n%s", out)
+		}
+	}
+}
+
+func TestAllowNestedPathsOutputFormats(t *testing.T) {
+	bin := buildBinary(t)
+
+	for _, format := range []string{"text", "json", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			args := []string{
+				"validate", "structure",
+				"--skip-orphans",
+				"--allow-nested-paths=assets/components,assets/components-extra",
+				"--output=" + format,
+				fixture(t, "nested-paths-skill"),
+			}
+			cmd := exec.Command(bin, args...)
+			out, _ := cmd.CombinedOutput()
+
+			if got := cmd.ProcessState.ExitCode(); got != 0 {
+				t.Errorf("exit code = %d, want 0\noutput: %s", got, out)
+			}
+			if !strings.Contains(string(out), "deep nesting allowed: assets/components/") {
+				t.Errorf("expected allowed-path info in %s output, got:\n%s", format, out)
+			}
+			if strings.Contains(string(out), "deep nesting detected:") {
+				t.Errorf("unexpected deep-nesting warning in %s output:\n%s", format, out)
 			}
 		})
 	}

--- a/cmd/validate_structure.go
+++ b/cmd/validate_structure.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/agent-ecosystem/skill-validator/structure"
@@ -13,6 +15,7 @@ var (
 	structAllowExtraFrontmatter bool
 	structAllowFlatLayouts      bool
 	structAllowDirs             []string
+	structAllowNestedPaths      []string
 )
 
 var validateStructureCmd = &cobra.Command{
@@ -33,10 +36,17 @@ func init() {
 		"allow files at the skill root without warnings and treat them as standard content for token counting")
 	validateStructureCmd.Flags().StringSliceVar(&structAllowDirs, "allow-dirs", nil,
 		"comma-separated list of directory names to accept without warnings (e.g. --allow-dirs=evals,testing)")
+	validateStructureCmd.Flags().StringSliceVar(&structAllowNestedPaths, "allow-nested-paths", nil,
+		"comma-separated skill-relative paths where deep nesting is allowed (e.g. --allow-nested-paths=assets/components)")
 	validateCmd.AddCommand(validateStructureCmd)
 }
 
 func runValidateStructure(cmd *cobra.Command, args []string) error {
+	allowNestedPaths, err := structure.NormalizeRelativePaths(structAllowNestedPaths)
+	if err != nil {
+		return fmt.Errorf("invalid --allow-nested-paths: %w", err)
+	}
+
 	_, mode, dirs, err := detectAndResolve(args)
 	if err != nil {
 		return err
@@ -47,6 +57,7 @@ func runValidateStructure(cmd *cobra.Command, args []string) error {
 		AllowExtraFrontmatter: structAllowExtraFrontmatter,
 		AllowFlatLayouts:      structAllowFlatLayouts,
 		AllowDirs:             structAllowDirs,
+		AllowNestedPaths:      allowNestedPaths,
 	}
 	eopts := exitOpts{strict: strictStructure}
 

--- a/structure/checks.go
+++ b/structure/checks.go
@@ -43,7 +43,8 @@ var knownExtraneousFiles = map[string]string{
 // for the required SKILL.md file, flags unrecognized directories and extraneous
 // root files, and warns about deep nesting in recognized directories.
 // Directories listed in opts.AllowDirs are accepted without warning and are
-// exempt from deep-nesting checks.
+// exempt from deep-nesting checks. Paths listed in opts.AllowNestedPaths are
+// exempt only from deep-nesting warnings within those subtrees.
 func CheckStructure(dir string, opts Options) []types.Result {
 	ctx := types.ResultContext{Category: "Structure"}
 	var results []types.Result
@@ -52,6 +53,14 @@ func CheckStructure(dir string, opts Options) []types.Result {
 	allowedDirs := make(map[string]bool, len(opts.AllowDirs))
 	for _, d := range opts.AllowDirs {
 		allowedDirs[d] = true
+	}
+
+	allowedNestedPaths := make([]string, 0, len(opts.AllowNestedPaths))
+	for _, p := range opts.AllowNestedPaths {
+		normalized, err := normalizeRelativePath(p)
+		if err == nil {
+			allowedNestedPaths = append(allowedNestedPaths, normalized)
+		}
 	}
 
 	// Check SKILL.md exists
@@ -109,7 +118,7 @@ func CheckStructure(dir string, opts Options) []types.Result {
 		if _, err := os.Stat(subdir); os.IsNotExist(err) {
 			continue
 		}
-		err := checkNesting(ctx, subdir, dirName)
+		err := checkNesting(ctx, subdir, dirName, allowedNestedPaths)
 		if err != nil {
 			results = append(results, err...)
 		}
@@ -158,7 +167,7 @@ func unknownDirHint(dir string) string {
 	return fmt.Sprintf("; should this be %s?", strings.Join(candidates, " or "))
 }
 
-func checkNesting(ctx types.ResultContext, dir, prefix string) []types.Result {
+func checkNesting(ctx types.ResultContext, dir, prefix string, allowedPaths []string) []types.Result {
 	var results []types.Result
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -169,7 +178,19 @@ func checkNesting(ctx types.ResultContext, dir, prefix string) []types.Result {
 			continue
 		}
 		if entry.IsDir() {
-			results = append(results, ctx.Warnf("deep nesting detected: %s/%s/", prefix, entry.Name()))
+			nestedPath := filepath.ToSlash(filepath.Join(prefix, entry.Name()))
+			allowed := false
+			for _, allowedPath := range allowedPaths {
+				if pathInSubtree(nestedPath, allowedPath) {
+					allowed = true
+					break
+				}
+			}
+			if allowed {
+				results = append(results, ctx.Infof("deep nesting allowed: %s/", nestedPath))
+				continue
+			}
+			results = append(results, ctx.Warnf("deep nesting detected: %s/", nestedPath))
 		}
 	}
 	return results

--- a/structure/checks_test.go
+++ b/structure/checks_test.go
@@ -165,6 +165,30 @@ func TestCheckStructure(t *testing.T) {
 		requireResult(t, results, types.Warning, "deep nesting detected: references/subdir/")
 	})
 
+	t.Run("allow-nested-paths suppresses only the selected subtree", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "assets/components/button/include.md", "button")
+		writeFile(t, dir, "assets/components-extra/card/include.md", "card")
+
+		results := CheckStructure(dir, Options{AllowNestedPaths: []string{"assets/components"}})
+
+		requireNoResultContaining(t, results, types.Warning, "deep nesting detected: assets/components/")
+		requireResult(t, results, types.Warning, "deep nesting detected: assets/components-extra/")
+		requireResultContaining(t, results, types.Info, "deep nesting allowed: assets/components/")
+	})
+
+	t.Run("allow-nested-paths accepts normalized Windows separators", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "SKILL.md", "content")
+		writeFile(t, dir, "assets/components/button/include.md", "button")
+
+		results := CheckStructure(dir, Options{AllowNestedPaths: []string{`assets\components`}})
+
+		requireNoResultContaining(t, results, types.Warning, "deep nesting detected: assets/components/")
+		requireResultContaining(t, results, types.Info, "deep nesting allowed: assets/components/")
+	})
+
 	t.Run("hidden files and dirs are skipped", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SKILL.md", "content")

--- a/structure/paths.go
+++ b/structure/paths.go
@@ -1,0 +1,58 @@
+package structure
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// NormalizeRelativePaths validates paths relative to a skill root and returns
+// them with slash separators. The normalized form is portable across operating
+// systems and safe to use for path-boundary comparisons.
+func NormalizeRelativePaths(paths []string) ([]string, error) {
+	normalized := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+
+	for _, raw := range paths {
+		value, err := normalizeRelativePath(raw)
+		if err != nil {
+			return nil, err
+		}
+		if !seen[value] {
+			normalized = append(normalized, value)
+			seen[value] = true
+		}
+	}
+
+	return normalized, nil
+}
+
+func normalizeRelativePath(raw string) (string, error) {
+	value := strings.TrimSpace(strings.ReplaceAll(raw, `\`, "/"))
+	if value == "" {
+		return "", fmt.Errorf("path must not be empty")
+	}
+	if strings.HasPrefix(value, "/") || hasWindowsVolume(value) {
+		return "", fmt.Errorf("%q must be relative to the skill root", raw)
+	}
+
+	value = path.Clean(value)
+	if value == "." {
+		return "", fmt.Errorf("%q must identify a path below the skill root", raw)
+	}
+	if value == ".." || strings.HasPrefix(value, "../") {
+		return "", fmt.Errorf("%q escapes the skill root", raw)
+	}
+
+	return value, nil
+}
+
+func hasWindowsVolume(value string) bool {
+	return len(value) >= 2 &&
+		((value[0] >= 'A' && value[0] <= 'Z') || (value[0] >= 'a' && value[0] <= 'z')) &&
+		value[1] == ':'
+}
+
+func pathInSubtree(candidate, subtree string) bool {
+	return candidate == subtree || strings.HasPrefix(candidate, subtree+"/")
+}

--- a/structure/paths_test.go
+++ b/structure/paths_test.go
@@ -1,0 +1,36 @@
+package structure
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeRelativePaths(t *testing.T) {
+	t.Run("normalizes separators and redundant components", func(t *testing.T) {
+		got, err := NormalizeRelativePaths([]string{`assets\components`, "references/./generated"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"assets/components", "references/generated"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("NormalizeRelativePaths() = %#v, want %#v", got, want)
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "Unix absolute", path: "/assets/components"},
+		{name: "Windows drive absolute", path: `C:\assets\components`},
+		{name: "Windows UNC absolute", path: `\\server\share\components`},
+		{name: "escapes root", path: "../components"},
+		{name: "escapes root after clean", path: "assets/../../components"},
+	} {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			if _, err := NormalizeRelativePaths([]string{tt.path}); err == nil {
+				t.Fatalf("NormalizeRelativePaths(%q) unexpectedly succeeded", tt.path)
+			}
+		})
+	}
+}

--- a/structure/validate.go
+++ b/structure/validate.go
@@ -15,6 +15,7 @@ type Options struct {
 	AllowExtraFrontmatter bool
 	AllowFlatLayouts      bool
 	AllowDirs             []string
+	AllowNestedPaths      []string
 }
 
 // ValidateMulti validates each directory and returns an aggregated report.

--- a/structure/validate_test.go
+++ b/structure/validate_test.go
@@ -168,6 +168,29 @@ func TestValidate(t *testing.T) {
 		requireResultContaining(t, report.Results, types.Error, "parsing frontmatter YAML")
 	})
 
+	t.Run("allow-nested-paths changes only nesting results", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n")
+		writeFile(t, dir, "assets/components/button/include.md", "unreferenced asset")
+
+		report := Validate(dir, Options{AllowNestedPaths: []string{"assets/components"}})
+
+		requireNoResultContaining(t, report.Results, types.Warning, "deep nesting detected: assets/components/")
+		requireResultContaining(t, report.Results, types.Info, "deep nesting allowed: assets/components/")
+		requireResultContaining(t, report.Results, types.Warning, "potentially unreferenced file: assets/components/button/include.md")
+
+		hasAssetTokenCount := false
+		for _, count := range report.TokenCounts {
+			if count.File == "assets/components/button/include.md" {
+				hasAssetTokenCount = true
+				break
+			}
+		}
+		if !hasAssetTokenCount {
+			t.Error("expected allowed nested path to remain in token accounting")
+		}
+	})
+
 	t.Run("allow-dirs suppresses unknown dir warning in full validation", func(t *testing.T) {
 		dir := t.TempDir()
 		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: A valid skill\n---\n# Body\n")

--- a/testdata/nested-paths-skill/SKILL.md
+++ b/testdata/nested-paths-skill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: nested-paths-skill
+description: A fixture with two intentionally nested asset bundles.
+---
+
+# Nested Paths Skill
+
+Use [the button component](assets/components/button/include.md) and
+[the extra component](assets/components-extra/card/include.md).

--- a/testdata/nested-paths-skill/assets/components-extra/card/include.md
+++ b/testdata/nested-paths-skill/assets/components-extra/card/include.md
@@ -1,0 +1,3 @@
+# Card
+
+Card component fixture.

--- a/testdata/nested-paths-skill/assets/components/button/include.md
+++ b/testdata/nested-paths-skill/assets/components/button/include.md
@@ -1,0 +1,3 @@
+# Button
+
+Button component fixture.


### PR DESCRIPTION
## What this PR does

Some valid skill packages intentionally group opt-in asset bundles under paths
such as `assets/components/<name>/`. Flattening those bundles only to satisfy the
generic deep-nesting warning makes the package harder to maintain.

This PR adds `--allow-nested-paths` to `validate structure` and `check`. The
option suppresses only deep-nesting warnings within explicitly selected,
skill-relative subtrees. Other structure, frontmatter, orphan, token, Markdown,
and link checks continue unchanged.

Paths are normalized across operating systems, matched on path boundaries, and
rejected when absolute or when they escape the skill root. A visible info result
is emitted whenever an exception is applied.

The main implementation lives in:

- `structure/paths.go` — portable relative-path validation and subtree matching
- `structure/checks.go` — scoped deep-nesting exception handling
- `cmd/{validate_structure,check}.go` — matching CLI flags and option propagation
- `structure/*_test.go`, `cmd/exitcode_integration_test.go`, and
  `testdata/nested-paths-skill/` — boundary, CLI, and output-format coverage

## How to test

```sh
go test -race ./... -count=1
golangci-lint run
```

The integration tests cover both commands, comma-separated paths, Windows
separators, invalid absolute/traversal paths, similar-prefix siblings, and text,
JSON, and Markdown output.

## Checklist

- [x] Tests pass locally (`go test -race ./... -count=1`)
- [x] Lint passes locally (`golangci-lint run`)
- [x] New functionality includes tests
- [x] Breaking changes are noted above (if any)
