### PR TITLE
feat(tokens): exclude selected paths from token accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Spec compliance is table stakes. `skill-validator` goes further: it checks that 
     - [Flat skill layouts](#flat-skill-layouts)
     - [Allowing non-standard directories](#allowing-non-standard-directories)
     - [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)
+    - [Excluding paths from non-standard token accounting](#excluding-paths-from-non-standard-token-accounting)
   - [Link validation](#link-validation-validate-links)
   - [Content analysis](#content-analysis-analyze-content)
   - [Contamination analysis](#contamination-analysis-analyze-contamination)
@@ -190,6 +191,7 @@ skill-validator validate structure --allow-extra-frontmatter <path>
 skill-validator validate structure --allow-flat-layouts <path>
 skill-validator validate structure --allow-dirs=evals,testing <path>
 skill-validator validate structure --allow-nested-paths=assets/components <path>
+skill-validator validate structure --exclude-token-paths=site <path>
 ```
 
 Checks spec compliance: directory structure, frontmatter fields, token limits, skill ratio, code fence integrity, internal link validity, and orphan file detection.
@@ -202,6 +204,7 @@ Checks spec compliance: directory structure, frontmatter fields, token limits, s
 | `--allow-flat-layouts` | Allow files at the skill root without warnings (see [Flat skill layouts](#flat-skill-layouts)) |
 | `--allow-dirs=evals,testing` | Accept specific non-standard directories without warnings (see [Allowing non-standard directories](#allowing-non-standard-directories)) |
 | `--allow-nested-paths=assets/components` | Allow deep nesting only within specific skill-relative paths (see [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)) |
+| `--exclude-token-paths=site` | Exclude specific skill-relative subtrees from non-standard token accounting (see [Excluding paths from non-standard token accounting](#excluding-paths-from-non-standard-token-accounting)) |
 
 ```
 Validating skill: my-skill/
@@ -300,6 +303,7 @@ skill-validator check --allow-extra-frontmatter <path>
 skill-validator check --allow-flat-layouts <path>
 skill-validator check --allow-dirs=evals,testing <path>
 skill-validator check --allow-nested-paths=assets/components <path>
+skill-validator check --exclude-token-paths=site <path>
 ```
 
 Runs all checks (structure + links + content + contamination).
@@ -315,6 +319,7 @@ Runs all checks (structure + links + content + contamination).
 | `--allow-flat-layouts` | Allow files at the skill root without warnings (see [Flat skill layouts](#flat-skill-layouts)) |
 | `--allow-dirs=evals,testing` | Accept specific non-standard directories without warnings (see [Allowing non-standard directories](#allowing-non-standard-directories)) |
 | `--allow-nested-paths=assets/components` | Allow deep nesting only within specific skill-relative paths (see [Allowing nesting at specific paths](#allowing-nesting-at-specific-paths)) |
+| `--exclude-token-paths=site` | Exclude specific skill-relative subtrees from non-standard token accounting (see [Excluding paths from non-standard token accounting](#excluding-paths-from-non-standard-token-accounting)) |
 
 Valid check groups: `structure`, `links`, `content`, `contamination`.
 
@@ -784,6 +789,21 @@ skill-validator check --allow-nested-paths=assets/components,assets/themes my-sk
 Paths are relative to the skill root. The flag accepts a comma-separated list or can be repeated, normalizes `/` and `\` separators, and rejects absolute paths or paths that escape the skill root. Matching observes path boundaries: allowing `assets/components` does not allow `assets/components-extra`.
 
 This option affects only deep-nesting warnings. Structure checks outside the selected subtree and all frontmatter, orphan, token, Markdown, and link checks continue unchanged. When a nesting warning is suppressed, the report includes an informational result identifying the allowed path.
+
+**Excluding paths from non-standard token accounting**
+
+Some skill packages commit generated output for portability or as a reference contract even though agents do not load it as instruction or reference content. Use `--exclude-token-paths` to remove an explicitly selected subtree from non-standard token accounting:
+
+```
+skill-validator validate structure --allow-dirs=site --exclude-token-paths=site my-skill/
+skill-validator check --allow-dirs=site --exclude-token-paths=site,dist my-skill/
+```
+
+Excluded files do not appear in the "Other files" per-file table, do not contribute to its aggregate token limit, and do not contribute to the holistic standard-to-non-standard content ratio. Other non-standard files remain counted.
+
+Paths are relative to the skill root. The flag accepts a comma-separated list or can be repeated, normalizes `/` and `\` separators, rejects absolute paths or paths that escape the skill root, and observes path boundaries. For example, excluding `site` does not exclude `site-extra`.
+
+This option affects only non-standard token accounting. It does not allow an unknown directory, suppress orphan detection, or bypass frontmatter, structure, Markdown, or link validation. When files are excluded, the report includes an informational result identifying the excluded path.
 
 ### Link validation (`validate links`)
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -22,6 +22,7 @@ var (
 	checkAllowFlatLayouts      bool
 	checkAllowDirs             []string
 	checkAllowNestedPaths      []string
+	checkExcludeTokenPaths     []string
 )
 
 var checkCmd = &cobra.Command{
@@ -47,6 +48,8 @@ func init() {
 		"comma-separated list of directory names to accept without warnings (e.g. --allow-dirs=evals,testing)")
 	checkCmd.Flags().StringSliceVar(&checkAllowNestedPaths, "allow-nested-paths", nil,
 		"comma-separated skill-relative paths where deep nesting is allowed (e.g. --allow-nested-paths=assets/components)")
+	checkCmd.Flags().StringSliceVar(&checkExcludeTokenPaths, "exclude-token-paths", nil,
+		"comma-separated skill-relative subtrees to exclude from non-standard token accounting (e.g. --exclude-token-paths=site)")
 	rootCmd.AddCommand(checkCmd)
 }
 
@@ -67,6 +70,11 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --allow-nested-paths: %w", err)
 	}
 
+	excludeTokenPaths, err := structure.NormalizeRelativePaths(checkExcludeTokenPaths)
+	if err != nil {
+		return fmt.Errorf("invalid --exclude-token-paths: %w", err)
+	}
+
 	enabled, err := resolveCheckGroups(checkOnly, checkSkip)
 	if err != nil {
 		return err
@@ -85,6 +93,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 			AllowFlatLayouts:      checkAllowFlatLayouts,
 			AllowDirs:             checkAllowDirs,
 			AllowNestedPaths:      allowNestedPaths,
+			ExcludeTokenPaths:     excludeTokenPaths,
 		},
 	}
 	eopts := exitOpts{strict: strictCheck}

--- a/cmd/exitcode_integration_test.go
+++ b/cmd/exitcode_integration_test.go
@@ -186,6 +186,13 @@ func TestSliceFlags(t *testing.T) {
 			wantStdout: "deep nesting allowed: assets/components/",
 			noStdout:   "deep nesting detected:",
 		},
+		{
+			name:       "check exclude-token-paths removes selected subtree only",
+			args:       []string{"check", "--only=structure", "--skip-orphans", "--allow-dirs=site,site-extra", "--exclude-token-paths=site", fixture(t, "token-exclusion-skill")},
+			wantCode:   0,
+			wantStdout: "site-extra/keep.md",
+			noStdout:   "site/generated.md",
+		},
 	}
 
 	for _, tt := range tests {
@@ -228,6 +235,24 @@ func TestAllowNestedPathsInvalidPath(t *testing.T) {
 	}
 }
 
+func TestExcludeTokenPathsInvalidPath(t *testing.T) {
+	bin := buildBinary(t)
+
+	for _, args := range [][]string{
+		{"validate", "structure", "--exclude-token-paths=/site", fixture(t, "valid-skill")},
+		{"check", "--exclude-token-paths=../site", fixture(t, "valid-skill")},
+	} {
+		cmd := exec.Command(bin, args...)
+		out, _ := cmd.CombinedOutput()
+		if got := cmd.ProcessState.ExitCode(); got != 3 {
+			t.Errorf("exit code = %d, want 3 (args: %v)\noutput: %s", got, args, out)
+		}
+		if !strings.Contains(string(out), "invalid --exclude-token-paths") {
+			t.Errorf("expected invalid path error, got:\n%s", out)
+		}
+	}
+}
+
 func TestAllowNestedPathsOutputFormats(t *testing.T) {
 	bin := buildBinary(t)
 
@@ -251,6 +276,38 @@ func TestAllowNestedPathsOutputFormats(t *testing.T) {
 			}
 			if strings.Contains(string(out), "deep nesting detected:") {
 				t.Errorf("unexpected deep-nesting warning in %s output:\n%s", format, out)
+			}
+		})
+	}
+}
+
+func TestExcludeTokenPathsOutputFormats(t *testing.T) {
+	bin := buildBinary(t)
+
+	for _, format := range []string{"text", "json", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			args := []string{
+				"validate", "structure",
+				"--skip-orphans",
+				"--allow-dirs=site,site-extra",
+				"--exclude-token-paths=site",
+				"--output=" + format,
+				fixture(t, "token-exclusion-skill"),
+			}
+			cmd := exec.Command(bin, args...)
+			out, _ := cmd.CombinedOutput()
+
+			if got := cmd.ProcessState.ExitCode(); got != 0 {
+				t.Errorf("exit code = %d, want 0\noutput: %s", got, out)
+			}
+			if !strings.Contains(string(out), "excluded from token accounting: site") {
+				t.Errorf("expected exclusion info in %s output, got:\n%s", format, out)
+			}
+			if strings.Contains(string(out), "site/generated.md") {
+				t.Errorf("excluded file appeared in %s output:\n%s", format, out)
+			}
+			if !strings.Contains(string(out), "site-extra/keep.md") {
+				t.Errorf("non-excluded sibling missing from %s output:\n%s", format, out)
 			}
 		})
 	}

--- a/cmd/validate_structure.go
+++ b/cmd/validate_structure.go
@@ -16,6 +16,7 @@ var (
 	structAllowFlatLayouts      bool
 	structAllowDirs             []string
 	structAllowNestedPaths      []string
+	structExcludeTokenPaths     []string
 )
 
 var validateStructureCmd = &cobra.Command{
@@ -38,6 +39,8 @@ func init() {
 		"comma-separated list of directory names to accept without warnings (e.g. --allow-dirs=evals,testing)")
 	validateStructureCmd.Flags().StringSliceVar(&structAllowNestedPaths, "allow-nested-paths", nil,
 		"comma-separated skill-relative paths where deep nesting is allowed (e.g. --allow-nested-paths=assets/components)")
+	validateStructureCmd.Flags().StringSliceVar(&structExcludeTokenPaths, "exclude-token-paths", nil,
+		"comma-separated skill-relative subtrees to exclude from non-standard token accounting (e.g. --exclude-token-paths=site)")
 	validateCmd.AddCommand(validateStructureCmd)
 }
 
@@ -45,6 +48,11 @@ func runValidateStructure(cmd *cobra.Command, args []string) error {
 	allowNestedPaths, err := structure.NormalizeRelativePaths(structAllowNestedPaths)
 	if err != nil {
 		return fmt.Errorf("invalid --allow-nested-paths: %w", err)
+	}
+
+	excludeTokenPaths, err := structure.NormalizeRelativePaths(structExcludeTokenPaths)
+	if err != nil {
+		return fmt.Errorf("invalid --exclude-token-paths: %w", err)
 	}
 
 	_, mode, dirs, err := detectAndResolve(args)
@@ -58,6 +66,7 @@ func runValidateStructure(cmd *cobra.Command, args []string) error {
 		AllowFlatLayouts:      structAllowFlatLayouts,
 		AllowDirs:             structAllowDirs,
 		AllowNestedPaths:      allowNestedPaths,
+		ExcludeTokenPaths:     excludeTokenPaths,
 	}
 	eopts := exitOpts{strict: strictStructure}
 

--- a/structure/paths.go
+++ b/structure/paths.go
@@ -27,6 +27,19 @@ func NormalizeRelativePaths(paths []string) ([]string, error) {
 	return normalized, nil
 }
 
+func normalizedRelativePaths(paths []string) []string {
+	normalized := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, raw := range paths {
+		value, err := normalizeRelativePath(raw)
+		if err == nil && !seen[value] {
+			normalized = append(normalized, value)
+			seen[value] = true
+		}
+	}
+	return normalized
+}
+
 func normalizeRelativePath(raw string) (string, error) {
 	value := strings.TrimSpace(strings.ReplaceAll(raw, `\`, "/"))
 	if value == "" {

--- a/structure/paths_test.go
+++ b/structure/paths_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestNormalizeRelativePaths(t *testing.T) {
 	t.Run("normalizes separators and redundant components", func(t *testing.T) {
-		got, err := NormalizeRelativePaths([]string{`assets\components`, "references/./generated"})
+		got, err := NormalizeRelativePaths([]string{`generated\site`, "docs/./generated"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := []string{"assets/components", "references/generated"}
+		want := []string{"generated/site", "docs/generated"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("NormalizeRelativePaths() = %#v, want %#v", got, want)
 		}
@@ -21,11 +21,11 @@ func TestNormalizeRelativePaths(t *testing.T) {
 		name string
 		path string
 	}{
-		{name: "Unix absolute", path: "/assets/components"},
-		{name: "Windows drive absolute", path: `C:\assets\components`},
-		{name: "Windows UNC absolute", path: `\\server\share\components`},
-		{name: "escapes root", path: "../components"},
-		{name: "escapes root after clean", path: "assets/../../components"},
+		{name: "Unix absolute", path: "/site"},
+		{name: "Windows drive absolute", path: `C:\site`},
+		{name: "Windows UNC absolute", path: `\\server\share\site`},
+		{name: "escapes root", path: "../site"},
+		{name: "escapes root after clean", path: "generated/../../site"},
 	} {
 		t.Run("rejects "+tt.name, func(t *testing.T) {
 			if _, err := NormalizeRelativePaths([]string{tt.path}); err == nil {

--- a/structure/tokens.go
+++ b/structure/tokens.go
@@ -171,7 +171,12 @@ func CheckTokens(dir, body string, opts Options) ([]types.Result, []types.TokenC
 	}
 
 	// Count tokens in non-standard files
-	otherCounts := countOtherFiles(dir, enc, opts)
+	exclusions := newTokenPathExclusions(opts.ExcludeTokenPaths)
+	otherCounts := countOtherFiles(dir, enc, opts, exclusions)
+
+	for _, excludedPath := range exclusions.appliedPaths() {
+		results = append(results, ctx.Infof("excluded from token accounting: %s", excludedPath))
+	}
 
 	// Check other-files aggregate limits
 	otherTotal := 0
@@ -278,7 +283,41 @@ func countAssetFiles(dir string, enc tokenizer.Codec) []types.TokenCount {
 	return counts
 }
 
-func countOtherFiles(dir string, enc tokenizer.Codec, opts Options) []types.TokenCount {
+type tokenPathExclusions struct {
+	paths   []string
+	applied map[string]bool
+}
+
+func newTokenPathExclusions(paths []string) *tokenPathExclusions {
+	normalized := normalizedRelativePaths(paths)
+	return &tokenPathExclusions{
+		paths:   normalized,
+		applied: make(map[string]bool, len(normalized)),
+	}
+}
+
+func (e *tokenPathExclusions) excludes(candidate string) bool {
+	candidate = filepath.ToSlash(candidate)
+	for _, excludedPath := range e.paths {
+		if pathInSubtree(candidate, excludedPath) {
+			e.applied[excludedPath] = true
+			return true
+		}
+	}
+	return false
+}
+
+func (e *tokenPathExclusions) appliedPaths() []string {
+	var paths []string
+	for _, excludedPath := range e.paths {
+		if e.applied[excludedPath] {
+			paths = append(paths, excludedPath)
+		}
+	}
+	return paths
+}
+
+func countOtherFiles(dir string, enc tokenizer.Codec, opts Options, exclusions *tokenPathExclusions) []types.TokenCount {
 	var counts []types.TokenCount
 
 	entries, err := os.ReadDir(dir)
@@ -296,13 +335,19 @@ func countOtherFiles(dir string, enc tokenizer.Codec, opts Options) []types.Toke
 			if standardDirs[strings.ToLower(name)] {
 				continue
 			}
+			if exclusions.excludes(name) {
+				continue
+			}
 			// Walk files in unknown directory
-			counts = append(counts, countFilesInDir(dir, name, enc)...)
+			counts = append(counts, countFilesInDir(dir, name, enc, exclusions)...)
 		} else {
 			if !entry.Type().IsRegular() {
 				continue
 			}
 			if standardRootFiles[strings.ToLower(name)] || opts.AllowFlatLayouts {
+				continue
+			}
+			if exclusions.excludes(name) {
 				continue
 			}
 			if binaryExtensions[strings.ToLower(filepath.Ext(name))] {
@@ -320,7 +365,7 @@ func countOtherFiles(dir string, enc tokenizer.Codec, opts Options) []types.Toke
 	return counts
 }
 
-func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec) []types.TokenCount {
+func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec, exclusions *tokenPathExclusions) []types.TokenCount {
 	var counts []types.TokenCount
 	fullDir := filepath.Join(rootDir, dirName)
 
@@ -332,9 +377,22 @@ func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec) []types.Token
 			if strings.HasPrefix(info.Name(), ".") && path != fullDir {
 				return filepath.SkipDir
 			}
+			if path != fullDir {
+				rel, relErr := filepath.Rel(rootDir, path)
+				if relErr == nil && exclusions.excludes(rel) {
+					return filepath.SkipDir
+				}
+			}
 			return nil
 		}
 		if strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(rootDir, path)
+		if relErr != nil {
+			return nil
+		}
+		if exclusions.excludes(rel) {
 			return nil
 		}
 		if binaryExtensions[strings.ToLower(filepath.Ext(info.Name()))] {
@@ -344,7 +402,6 @@ func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec) []types.Token
 		if err != nil {
 			return nil
 		}
-		rel, _ := filepath.Rel(rootDir, path)
 		tokens, _, _ := enc.Encode(string(data))
 		counts = append(counts, types.TokenCount{File: filepath.ToSlash(rel), Tokens: len(tokens)})
 		return nil

--- a/structure/tokens_test.go
+++ b/structure/tokens_test.go
@@ -266,6 +266,53 @@ func TestCountOtherFiles(t *testing.T) {
 			t.Fatalf("expected 0 other counts, got %d", len(otherCounts))
 		}
 	})
+
+	t.Run("exclude-token-paths removes only the selected subtree", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "site/index.html", "generated site")
+		writeFile(t, dir, "site/assets/app.js", "generated JavaScript")
+		writeFile(t, dir, "site-extra/index.html", "must remain")
+		writeFile(t, dir, "docs/guide.md", "must also remain")
+
+		results, _, otherCounts := CheckTokens(dir, "body", Options{ExcludeTokenPaths: []string{"site"}})
+
+		files := tokenCountFiles(otherCounts)
+		if files["site/index.html"] || files["site/assets/app.js"] {
+			t.Errorf("excluded site subtree remained in token counts: %#v", files)
+		}
+		if !files["site-extra/index.html"] {
+			t.Error("similar-prefix sibling site-extra/index.html was incorrectly excluded")
+		}
+		if !files["docs/guide.md"] {
+			t.Error("non-excluded docs/guide.md was incorrectly excluded")
+		}
+		requireResultContaining(t, results, types.Info, "excluded from token accounting: site")
+	})
+
+	t.Run("exclude-token-paths normalizes Windows separators", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "generated/site/index.html", "generated site")
+		writeFile(t, dir, "generated/source.md", "must remain")
+
+		results, _, otherCounts := CheckTokens(dir, "body", Options{ExcludeTokenPaths: []string{`generated\site`}})
+
+		files := tokenCountFiles(otherCounts)
+		if files["generated/site/index.html"] {
+			t.Error("Windows-separated excluded path remained in token counts")
+		}
+		if !files["generated/source.md"] {
+			t.Error("sibling file outside excluded subtree was incorrectly excluded")
+		}
+		requireResultContaining(t, results, types.Info, "excluded from token accounting: generated/site")
+	})
+}
+
+func tokenCountFiles(counts []types.TokenCount) map[string]bool {
+	files := make(map[string]bool, len(counts))
+	for _, count := range counts {
+		files[count.File] = true
+	}
+	return files
 }
 
 func TestCheckTokens_OtherFilesLimits(t *testing.T) {
@@ -297,6 +344,41 @@ func TestCheckTokens_OtherFilesLimits(t *testing.T) {
 		results, _, _ := CheckTokens(dir, "body", Options{})
 		requireResultContaining(t, results, types.Error, "non-standard files total")
 		requireResultContaining(t, results, types.Error, "severely degrade performance")
+	})
+
+	t.Run("excluded content does not contribute to aggregate limit", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "site/generated.md", generateContent(30_000))
+		writeFile(t, dir, "docs/guide.md", generateContent(5_000))
+
+		results, _, otherCounts := CheckTokens(dir, "body", Options{ExcludeTokenPaths: []string{"site"}})
+
+		requireNoResultContaining(t, results, types.Warning, "non-standard files total")
+		requireNoResultContaining(t, results, types.Error, "non-standard files total")
+		files := tokenCountFiles(otherCounts)
+		if files["site/generated.md"] {
+			t.Error("excluded file contributed to other token counts")
+		}
+		if !files["docs/guide.md"] {
+			t.Error("non-excluded content should remain in other token counts")
+		}
+	})
+
+	t.Run("non-excluded content still triggers aggregate limit", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "site/generated.md", generateContent(30_000))
+		writeFile(t, dir, "docs/guide.md", generateContent(30_000))
+
+		results, _, otherCounts := CheckTokens(dir, "body", Options{ExcludeTokenPaths: []string{"site"}})
+
+		requireResultContaining(t, results, types.Warning, "non-standard files total")
+		files := tokenCountFiles(otherCounts)
+		if files["site/generated.md"] {
+			t.Error("excluded file contributed to other token counts")
+		}
+		if !files["docs/guide.md"] {
+			t.Error("non-excluded warning-producing content should remain counted")
+		}
 	})
 }
 

--- a/structure/validate.go
+++ b/structure/validate.go
@@ -16,6 +16,7 @@ type Options struct {
 	AllowFlatLayouts      bool
 	AllowDirs             []string
 	AllowNestedPaths      []string
+	ExcludeTokenPaths     []string
 }
 
 // ValidateMulti validates each directory and returns an aggregated report.

--- a/structure/validate_test.go
+++ b/structure/validate_test.go
@@ -107,6 +107,47 @@ func TestValidate(t *testing.T) {
 		requireResultContaining(t, report.Results, types.Error, "build pipeline issue")
 	})
 
+	t.Run("excluded token paths do not contribute to skill ratio", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n")
+		writeFile(t, dir, "site/generated.md", generateContent(30_000))
+		writeFile(t, dir, "docs/guide.md", "small non-standard content")
+
+		report := Validate(dir, Options{
+			AllowDirs:         []string{"site", "docs"},
+			ExcludeTokenPaths: []string{"site"},
+			SkipOrphans:       true,
+		})
+
+		requireNoResultContaining(t, report.Results, types.Error, "doesn't appear to be structured as a skill")
+		files := tokenCountFiles(report.OtherTokenCounts)
+		if files["site/generated.md"] {
+			t.Error("excluded site content contributed to holistic ratio inputs")
+		}
+		if !files["docs/guide.md"] {
+			t.Error("non-excluded content should remain in holistic ratio inputs")
+		}
+		requireResultContaining(t, report.Results, types.Info, "excluded from token accounting: site")
+	})
+
+	t.Run("excluded token paths remain subject to structure and link checks", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n[missing](site/missing.md)\n")
+		writeFile(t, dir, "site/generated.md", "generated content")
+
+		report := Validate(dir, Options{
+			ExcludeTokenPaths: []string{"site"},
+			SkipOrphans:       true,
+		})
+
+		requireResultContaining(t, report.Results, types.Warning, "unknown directory: site/")
+		requireResultContaining(t, report.Results, types.Error, "broken internal link: site/missing.md")
+		requireResultContaining(t, report.Results, types.Info, "excluded from token accounting: site")
+		if len(report.OtherTokenCounts) != 0 {
+			t.Errorf("expected excluded site to be absent from other token counts, got %#v", report.OtherTokenCounts)
+		}
+	})
+
 	t.Run("no skill ratio error when other content is small", func(t *testing.T) {
 		dir := t.TempDir()
 		writeSkill(t, dir, "---\nname: "+dirName(dir)+"\ndescription: desc\n---\n# Body\n")

--- a/testdata/token-exclusion-skill/SKILL.md
+++ b/testdata/token-exclusion-skill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: token-exclusion-skill
+description: A fixture with generated and non-generated non-standard content.
+---
+
+# Token Exclusion Skill
+
+Validate all package structure while excluding selected generated files from
+token accounting.

--- a/testdata/token-exclusion-skill/site-extra/keep.md
+++ b/testdata/token-exclusion-skill/site-extra/keep.md
@@ -1,0 +1,3 @@
+# Keep
+
+This similar-prefix sibling must remain in token accounting.

--- a/testdata/token-exclusion-skill/site/generated.md
+++ b/testdata/token-exclusion-skill/site/generated.md
@@ -1,0 +1,3 @@
+# Generated Site
+
+This generated file should be excluded from token accounting.


### PR DESCRIPTION
## What this PR does

Some skill packages commit generated output for portability or because the
generated reference site is part of the package contract. Those files are not
agent instructions or references, but they currently contribute to
non-standard token warnings and the holistic structure ratio.

This PR adds `--exclude-token-paths` to `validate structure` and `check`.
Explicitly selected, skill-relative subtrees are excluded from non-standard
per-file token output, the Other files aggregate, and the holistic
standard-to-non-standard ratio. Non-excluded content remains counted, and the
option does not suppress structure, orphan, frontmatter, Markdown, or link
validation.

Paths are normalized across operating systems, matched on path boundaries, and
rejected when absolute or when they escape the skill root. A visible info result
is emitted whenever an exclusion is applied.

The main implementation lives in:

- `structure/paths.go` — portable relative-path validation and subtree matching
- `structure/tokens.go` — filtered non-standard file traversal and accounting
- `cmd/{validate_structure,check}.go` — matching CLI flags and option propagation
- `structure/*_test.go`, `cmd/exitcode_integration_test.go`, and
  `testdata/token-exclusion-skill/` — aggregation, ratio, boundary, CLI, and
  output-format coverage

## How to test

```sh
go test -race ./... -count=1
golangci-lint run
```

The integration tests cover both commands, Windows separators, invalid
absolute/traversal paths, similar-prefix siblings, retained non-excluded
content, and text, JSON, and Markdown output.

## Checklist

- [x] Tests pass locally (`go test -race ./... -count=1`)
- [x] Lint passes locally (`golangci-lint run`)
- [x] New functionality includes tests
- [x] Breaking changes are noted above (if any)
