### PR TITLE
Match file references on path-word boundaries

### DIFF
--- a/structure/orphans.go
+++ b/structure/orphans.go
@@ -238,16 +238,38 @@ func filesInDir(inventory []string, dir string) []string {
 // references/guide.md might reference images/diagram.png, which should match the
 // inventory entry references/images/diagram.png.
 func containsReference(text, sourceDir, relPath string) bool {
-	// Direct match: the full root-relative path appears in the text.
-	if strings.Contains(text, relPath) {
+	return matchesReference(text, sourceDir, relPath, false)
+}
+
+// containsReferenceWithoutExtension is like containsReference but strips the
+// file extension before matching. This catches cases where skill authors
+// reference scripts without the extension (e.g., "scripts/check_fillable_fields"
+// instead of "scripts/check_fillable_fields.py"). The sourceDir-relative
+// fallback is skipped when it would reduce to a bare filename: without an
+// extension or a directory separator, that form is indistinguishable from an
+// ordinary word in prose (a same-directory sibling of lint.yml would
+// otherwise match every "lint" in the text — see issue #85).
+func containsReferenceWithoutExtension(text, sourceDir, relPath string) bool {
+	ext := filepath.Ext(relPath)
+	if ext == "" {
+		return false
+	}
+	return matchesReference(text, sourceDir, strings.TrimSuffix(relPath, ext), true)
+}
+
+// matchesReference reports whether text mentions relPath by its root-relative
+// form or by its form relative to sourceDir. When relRequiresDir is set, the
+// sourceDir-relative fallback only applies if that form still contains a
+// directory separator.
+func matchesReference(text, sourceDir, relPath string, relRequiresDir bool) bool {
+	if containsPathToken(text, relPath) {
 		return true
 	}
-	// Relative match: if the source is in a subdirectory, check whether the
-	// path relative to that directory appears in the text.
 	if sourceDir != "" {
 		rel, err := filepath.Rel(sourceDir, relPath)
 		if err == nil && !strings.HasPrefix(rel, "..") {
-			if strings.Contains(text, filepath.ToSlash(rel)) {
+			relSlash := filepath.ToSlash(rel)
+			if (!relRequiresDir || strings.Contains(relSlash, "/")) && containsPathToken(text, relSlash) {
 				return true
 			}
 		}
@@ -255,17 +277,28 @@ func containsReference(text, sourceDir, relPath string) bool {
 	return false
 }
 
-// containsReferenceWithoutExtension is like containsReference but strips the
-// file extension before matching. This catches cases where skill authors
-// reference scripts without the extension (e.g., "scripts/check_fillable_fields"
-// instead of "scripts/check_fillable_fields.py").
-func containsReferenceWithoutExtension(text, sourceDir, relPath string) bool {
-	ext := filepath.Ext(relPath)
-	if ext == "" {
-		return false
+// containsPathToken reports whether token occurs in text with path-word
+// boundaries on both sides, so references/lint does not match inside
+// references/linting and lint.yml does not match inside eslint.yml.
+func containsPathToken(text, token string) bool {
+	for start := 0; ; start++ {
+		i := strings.Index(text[start:], token)
+		if i < 0 {
+			return false
+		}
+		start += i
+		end := start + len(token)
+		beforeOK := start == 0 || !isPathWordByte(text[start-1])
+		afterOK := end == len(text) || !isPathWordByte(text[end])
+		if beforeOK && afterOK {
+			return true
+		}
 	}
-	noExt := strings.TrimSuffix(relPath, ext)
-	return containsReference(text, sourceDir, noExt)
+}
+
+func isPathWordByte(b byte) bool {
+	return b == '_' || b == '-' ||
+		('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') || ('0' <= b && b <= '9')
 }
 
 // markReached marks a file as reached, reads it if it's a text file, and

--- a/structure/orphans_test.go
+++ b/structure/orphans_test.go
@@ -1,6 +1,7 @@
 package structure
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/agent-ecosystem/skill-validator/types"
@@ -31,6 +32,26 @@ func TestCheckOrphanFiles(t *testing.T) {
 		results := CheckOrphanFiles(dir, body, Options{})
 
 		requireResultContaining(t, results, types.Warning, "potentially unreferenced file: references/unused.md")
+	})
+
+	// Issue #85: a sibling file whose extensionless name is an ordinary word
+	// ("lint") must not be treated as referenced by prose in the same
+	// directory. The unreferenced file gets an orphan warning, not a
+	// misleading missing-extension warning.
+	t.Run("prose word matching sibling filename is not a reference", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "references/checklist.md", "Run the lint step before committing. Linting catches most problems.")
+		writeFile(t, dir, "references/lint.yml", "name: lint\non: [push]\n")
+
+		body := "See references/checklist.md for details."
+		results := CheckOrphanFiles(dir, body, Options{})
+
+		for _, r := range results {
+			if strings.Contains(r.Message, "referenced without its extension") {
+				t.Errorf("unexpected missing-extension warning: %s", r.Message)
+			}
+		}
+		requireResultContaining(t, results, types.Warning, "potentially unreferenced file: references/lint.yml")
 	})
 
 	t.Run("orphan in scripts", func(t *testing.T) {
@@ -277,10 +298,12 @@ func TestCheckOrphanFiles(t *testing.T) {
 		body := "Run scripts/main.py to start."
 		results := CheckOrphanFiles(dir, body, Options{})
 
-		// .sh file should not be resolved by Python imports; it's matched
-		// via the extensionless fallback since "data_loader" appears in the text
+		// .sh file is not resolved by Python imports ("import data_loader"
+		// refers to a Python module, not the shell script), and the bare
+		// identifier in main.py is not treated as a same-directory reference
+		// (see issue #85), so the file is reported as unreferenced.
 		requireResultContaining(t, results, types.Warning,
-			"file scripts/data_loader.sh is referenced without its extension")
+			"potentially unreferenced file: scripts/data_loader.sh")
 	})
 
 	t.Run("__init__.py bridges package imports to sibling modules", func(t *testing.T) {
@@ -394,6 +417,74 @@ func TestContainsReference(t *testing.T) {
 			t.Error("expected relative path from subdirectory to match")
 		}
 	})
+
+	t.Run("does not match inside a longer filename", func(t *testing.T) {
+		if containsReference("Configure eslint.yml before running.", "references", "references/lint.yml") {
+			t.Error("lint.yml should not match inside eslint.yml")
+		}
+		if containsReference("See references/linting.md for details.", "", "references/lint.md") {
+			t.Error("references/lint.md should not match inside references/linting.md")
+		}
+	})
+
+	t.Run("same-directory mention with extension still matches", func(t *testing.T) {
+		if !containsReference("The workflow lives in lint.yml in this directory.", "references", "references/lint.yml") {
+			t.Error("expected bare-filename mention with extension to match")
+		}
+	})
+}
+
+func TestContainsReferenceWithoutExtension(t *testing.T) {
+	// Issue #85: a same-directory sibling reduces the extensionless form to a
+	// bare word, which must not match ordinary prose.
+	t.Run("bare word in prose does not match", func(t *testing.T) {
+		text := "Run the lint step before committing. Linting catches most problems."
+		if containsReferenceWithoutExtension(text, "references", "references/lint.yml") {
+			t.Error("prose word 'lint' should not count as a reference to references/lint.yml")
+		}
+	})
+
+	t.Run("extensionless path with separator matches", func(t *testing.T) {
+		text := "Run scripts/check_fillable_fields to inspect the form."
+		if !containsReferenceWithoutExtension(text, "", "scripts/check_fillable_fields.py") {
+			t.Error("expected extensionless path with directory to match")
+		}
+	})
+
+	t.Run("extensionless path respects word boundaries", func(t *testing.T) {
+		if containsReferenceWithoutExtension("See references/linting for details.", "", "references/lint.yml") {
+			t.Error("references/lint should not match inside references/linting")
+		}
+	})
+
+	t.Run("relative extensionless path with separator matches", func(t *testing.T) {
+		text := "Run images/render to regenerate."
+		if !containsReferenceWithoutExtension(text, "references", "references/images/render.py") {
+			t.Error("expected sourceDir-relative extensionless path to match")
+		}
+	})
+}
+
+func TestContainsPathToken(t *testing.T) {
+	tests := []struct {
+		text, token string
+		want        bool
+	}{
+		{"see references/lint.yml here", "references/lint.yml", true},
+		{"references/lint.yml", "references/lint.yml", true},
+		{"(references/lint.yml)", "references/lint.yml", true},
+		{"./references/lint.yml", "references/lint.yml", true},
+		{"my-references/lint.yml", "references/lint.yml", false},
+		{"references/lint.yml2", "references/lint.yml", false},
+		{"eslint.yml", "lint.yml", false},
+		{"lint.yml.bak then lint.yml", "lint.yml", true},
+		{"", "lint.yml", false},
+	}
+	for _, tt := range tests {
+		if got := containsPathToken(tt.text, tt.token); got != tt.want {
+			t.Errorf("containsPathToken(%q, %q) = %v, want %v", tt.text, tt.token, got, tt.want)
+		}
+	}
 }
 
 func TestFilesInDir(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Fixes #85, where `references/lint.yml` was reported as "referenced without its extension (as references/lint in references/check-skill-nonlinks.md)" even though that file never contains `references/lint`.

Root cause: when the referencing file and the inventory file share a directory, `containsReference`'s sourceDir-relative fallback reduces the needle to a bare filename. The extensionless variant then reduced `references/lint.yml` to the single word `lint` and substring-matched it against ordinary prose ("Run the lint step…", "Linting catches…").

Two changes:

- Reference matching now requires path-word boundaries on both sides of a match, so `references/lint` no longer matches inside `references/linting`, and `lint.yml` no longer matches inside `eslint.yml`.
- The extensionless sourceDir-relative fallback is skipped when it would reduce to a bare filename. Root-relative matching is unchanged: flat layouts still resolve `helper` to `helper.py`, and nested skills still resolve `scripts/check_fillable_fields` to the `.py` file.

One test intentionally updated: `Python import does not match non-Python files` previously relied on the bare-word fallback to claim `data_loader.sh` was "referenced without its extension" by `import data_loader`. A Python import cannot reference a shell script, so the accurate outcome — now asserted — is an unreferenced-file warning.

## How to test

Reproduced the report with a minimal fixture (a `references/lint.yml` beside a markdown file whose prose mentions "lint"): before this change it produces the false extension warning; after, it produces the truthful "potentially unreferenced file" warning. Also:

- `go test -race ./... -count=1`
- `go vet ./...`, `gofmt -l .`

## Checklist

- [x] Tests pass locally (`go test -race ./... -count=1`)
- [x] Lint passes locally (`golangci-lint run`)
- [x] New functionality includes tests
- [ ] Breaking changes are noted above (if any)