### PR TITLE
Enforce symlink containment for reads and internal links

### DIFF
--- a/skill/skill.go
+++ b/skill/skill.go
@@ -82,7 +82,7 @@ var knownFrontmatterFields = map[string]bool{
 // Load reads and parses a SKILL.md file from the given directory.
 func Load(dir string) (*Skill, error) {
 	path := filepath.Join(dir, "SKILL.md")
-	data, err := util.SafeReadFile(path)
+	data, err := util.SafeReadFile(dir, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading SKILL.md: %w", err)
 	}

--- a/skillcheck/validator.go
+++ b/skillcheck/validator.go
@@ -57,7 +57,7 @@ func DetectSkills(dir string) (types.SkillMode, []string) {
 // frontmatter. This is used as a fallback for content/contamination analysis when
 // frontmatter parsing fails.
 func ReadSkillRaw(dir string) string {
-	data, err := util.SafeReadFile(filepath.Join(dir, "SKILL.md"))
+	data, err := util.SafeReadFile(dir, filepath.Join(dir, "SKILL.md"))
 	if err != nil {
 		return ""
 	}
@@ -82,7 +82,7 @@ func ReadReferencesMarkdownFiles(dir string) map[string]string {
 		if !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
 			continue
 		}
-		data, err := util.SafeReadFile(filepath.Join(refsDir, entry.Name()))
+		data, err := util.SafeReadFile(dir, filepath.Join(refsDir, entry.Name()))
 		if err != nil {
 			continue
 		}

--- a/skillcheck/validator_test.go
+++ b/skillcheck/validator_test.go
@@ -85,6 +85,31 @@ func TestReadReferencesMarkdownFiles(t *testing.T) {
 	}
 }
 
+// Issue #88: when references/ itself is a symlink to a directory outside the
+// skill tree, the regular files inside pass a leaf-only check. Their content
+// must not be read and shipped to the LLM judge.
+func TestReadReferencesMarkdownFiles_SkipsSymlinkedDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require admin on Windows")
+	}
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "leak.md"), []byte("SHOULD-NOT-LEAK"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "references")); err != nil {
+		t.Fatal(err)
+	}
+
+	files := ReadReferencesMarkdownFiles(dir)
+	for name, content := range files {
+		if strings.Contains(content, "SHOULD-NOT-LEAK") {
+			t.Errorf("out-of-tree content leaked via %s", name)
+		}
+	}
+}
+
 func TestReadReferencesMarkdownFiles_SkipsSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks require admin on Windows")

--- a/structure/links.go
+++ b/structure/links.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/agent-ecosystem/skill-validator/links"
 	"github.com/agent-ecosystem/skill-validator/types"
+	"github.com/agent-ecosystem/skill-validator/util"
 )
 
 // CheckInternalLinks validates relative (internal) links in the skill body.
@@ -48,9 +49,16 @@ func CheckInternalLinks(dir, body string) []types.Result {
 		}
 		if _, err := os.Stat(resolved); os.IsNotExist(err) {
 			results = append(results, ctx.Errorf("broken internal link: %s (file not found)", link))
-		} else {
-			results = append(results, ctx.Passf("internal link: %s (exists)", link))
+			continue
 		}
+		// The syntactic check above cannot see symlinks: a path that looks
+		// internal may still resolve outside the skill directory.
+		inside, err := util.ResolvesWithin(dir, resolved)
+		if err != nil || !inside {
+			results = append(results, ctx.Errorf("internal link escapes skill directory: %s (resolves outside the skill package)", link))
+			continue
+		}
+		results = append(results, ctx.Passf("internal link: %s (exists)", link))
 	}
 
 	return results

--- a/structure/links_test.go
+++ b/structure/links_test.go
@@ -1,6 +1,9 @@
 package structure
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/agent-ecosystem/skill-validator/types"
@@ -20,6 +23,46 @@ func TestCheckInternalLinks(t *testing.T) {
 		body := "See [guide](references/missing.md)."
 		results := CheckInternalLinks(dir, body)
 		requireResult(t, results, types.Error, "broken internal link: references/missing.md (file not found)")
+	})
+
+	// Issue #86: a link that looks internal syntactically may be a symlink
+	// whose target resolves outside the skill directory.
+	t.Run("symlink escaping skill directory is rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlinks require admin on Windows")
+		}
+		outside := t.TempDir()
+		secret := filepath.Join(outside, "secret.md")
+		if err := os.WriteFile(secret, []byte("OUT-OF-TREE"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "references"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(secret, filepath.Join(dir, "references", "guide.md")); err != nil {
+			t.Fatal(err)
+		}
+
+		body := "See [guide](references/guide.md)."
+		results := CheckInternalLinks(dir, body)
+		requireResult(t, results, types.Error, "internal link escapes skill directory: references/guide.md (resolves outside the skill package)")
+	})
+
+	t.Run("symlink resolving inside skill directory passes", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlinks require admin on Windows")
+		}
+		dir := t.TempDir()
+		writeFile(t, dir, "references/real.md", "content")
+		if err := os.Symlink(filepath.Join(dir, "references", "real.md"), filepath.Join(dir, "references", "alias.md")); err != nil {
+			t.Fatal(err)
+		}
+
+		body := "See [alias](references/alias.md)."
+		results := CheckInternalLinks(dir, body)
+		requireResult(t, results, types.Pass, "internal link: references/alias.md (exists)")
 	})
 
 	t.Run("skips HTTP links", func(t *testing.T) {

--- a/structure/markdown.go
+++ b/structure/markdown.go
@@ -39,7 +39,7 @@ func CheckMarkdown(dir, body string) []types.Result {
 		if !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
 			continue
 		}
-		data, err := util.SafeReadFile(filepath.Join(refsDir, entry.Name()))
+		data, err := util.SafeReadFile(dir, filepath.Join(refsDir, entry.Name()))
 		if err != nil {
 			continue
 		}

--- a/structure/orphans.go
+++ b/structure/orphans.go
@@ -86,7 +86,7 @@ func CheckOrphanFiles(dir, body string, opts Options) []types.Result {
 			}
 			if strings.Contains(lowerText, strings.ToLower(rf)) {
 				scannedRootFiles[rf] = true
-				data, err := util.SafeReadFile(filepath.Join(dir, rf))
+				data, err := util.SafeReadFile(dir, filepath.Join(dir, rf))
 				if err == nil {
 					queue = append(queue, queueItem{text: string(data), source: rf})
 				}
@@ -123,7 +123,7 @@ func CheckOrphanFiles(dir, body string, opts Options) []types.Result {
 					continue
 				}
 				scannedInitFiles[initPath] = true
-				data, err := util.SafeReadFile(filepath.Join(dir, initPath))
+				data, err := util.SafeReadFile(dir, filepath.Join(dir, initPath))
 				if err == nil {
 					queue = append(queue, queueItem{text: string(data), source: initPath})
 				}
@@ -308,7 +308,7 @@ func markReached(relPath, source, dir string, queue *[]queueItem, reached map[st
 	reachedFrom[relPath] = source
 
 	if isTextFile(relPath) {
-		data, err := util.SafeReadFile(filepath.Join(dir, relPath))
+		data, err := util.SafeReadFile(dir, filepath.Join(dir, relPath))
 		if err == nil {
 			*queue = append(*queue, queueItem{text: string(data), source: relPath})
 		}

--- a/structure/tokens.go
+++ b/structure/tokens.go
@@ -14,8 +14,8 @@ import (
 
 const maxTokenizedFileBytes = 8 * 1024 * 1024
 
-func readFileWithCap(path string) ([]byte, error) {
-	data, err := util.SafeReadFile(path)
+func readFileWithCap(root, path string) ([]byte, error) {
+	data, err := util.SafeReadFile(root, path)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func CheckTokens(dir, body string, opts Options) ([]types.Result, []types.TokenC
 				continue
 			}
 			path := filepath.Join(refsDir, entry.Name())
-			data, err := readFileWithCap(path)
+			data, err := readFileWithCap(dir, path)
 			if err != nil {
 				relPath := "references/" + entry.Name()
 				results = append(results, ctx.WarnFilef(relPath, "could not read %s: %v", relPath, err))
@@ -270,7 +270,7 @@ func countAssetFiles(dir string, enc tokenizer.Codec) []types.TokenCount {
 		if !textAssetExtensions[ext] {
 			return nil
 		}
-		data, err := readFileWithCap(path)
+		data, err := readFileWithCap(dir, path)
 		if err != nil {
 			return nil
 		}
@@ -353,7 +353,7 @@ func countOtherFiles(dir string, enc tokenizer.Codec, opts Options, exclusions *
 			if binaryExtensions[strings.ToLower(filepath.Ext(name))] {
 				continue
 			}
-			data, err := readFileWithCap(filepath.Join(dir, name))
+			data, err := readFileWithCap(dir, filepath.Join(dir, name))
 			if err != nil {
 				continue
 			}
@@ -398,7 +398,7 @@ func countFilesInDir(rootDir, dirName string, enc tokenizer.Codec, exclusions *t
 		if binaryExtensions[strings.ToLower(filepath.Ext(info.Name()))] {
 			return nil
 		}
-		data, err := readFileWithCap(path)
+		data, err := readFileWithCap(rootDir, path)
 		if err != nil {
 			return nil
 		}
@@ -432,7 +432,7 @@ func countRootFiles(dir string, enc tokenizer.Codec) []types.TokenCount {
 		if binaryExtensions[strings.ToLower(filepath.Ext(name))] {
 			continue
 		}
-		data, err := readFileWithCap(filepath.Join(dir, name))
+		data, err := readFileWithCap(dir, filepath.Join(dir, name))
 		if err != nil {
 			continue
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -10,19 +10,50 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
-var ErrUnsafeFile = errors.New("refusing to read non-regular file")
+var ErrUnsafeFile = errors.New("refusing to read unsafe file")
 
-func SafeReadFile(path string) ([]byte, error) {
+// SafeReadFile reads a file from an untrusted skill package rooted at root.
+// It refuses non-regular files (symlinks, devices, pipes) and paths that
+// resolve outside root after following symlinks in any parent directory, so
+// a symlinked file or a symlinked directory inside the package cannot leak
+// content from elsewhere on the machine.
+func SafeReadFile(root, path string) ([]byte, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%w: %s", ErrUnsafeFile, path)
+		return nil, fmt.Errorf("%w: %s is not a regular file", ErrUnsafeFile, path)
+	}
+	inside, err := ResolvesWithin(root, path)
+	if err != nil {
+		return nil, err
+	}
+	if !inside {
+		return nil, fmt.Errorf("%w: %s resolves outside the skill directory", ErrUnsafeFile, path)
 	}
 	return os.ReadFile(path)
+}
+
+// ResolvesWithin reports whether path, after resolving all symlinks in both
+// arguments, remains inside root. The path must exist.
+func ResolvesWithin(root, path string) (bool, error) {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false, err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolved)
+	if err != nil {
+		return false, err
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)), nil
 }
 
 func IsRegularFile(path string) bool {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -95,7 +95,7 @@ func TestSafeReadFile(t *testing.T) {
 	if err := os.WriteFile(regular, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := SafeReadFile(regular)
+	got, err := SafeReadFile(dir, regular)
 	if err != nil {
 		t.Fatalf("SafeReadFile(regular): %v", err)
 	}
@@ -116,7 +116,7 @@ func TestSafeReadFile(t *testing.T) {
 		if err := os.Symlink(secret, link); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := SafeReadFile(link); !errors.Is(err, ErrUnsafeFile) {
+		if _, err := SafeReadFile(dir, link); !errors.Is(err, ErrUnsafeFile) {
 			t.Errorf("SafeReadFile(symlink) error = %v, want ErrUnsafeFile", err)
 		}
 		if IsRegularFile(link) {
@@ -125,14 +125,75 @@ func TestSafeReadFile(t *testing.T) {
 	}
 
 	missing := filepath.Join(dir, "missing.txt")
-	if _, err := SafeReadFile(missing); err == nil {
+	if _, err := SafeReadFile(dir, missing); err == nil {
 		t.Errorf("SafeReadFile(missing) error = nil, want non-nil")
 	}
 	if IsRegularFile(missing) {
 		t.Errorf("IsRegularFile(missing) = true, want false")
 	}
 
-	if _, err := SafeReadFile(dir); !errors.Is(err, ErrUnsafeFile) {
+	if _, err := SafeReadFile(dir, dir); !errors.Is(err, ErrUnsafeFile) {
 		t.Errorf("SafeReadFile(dir) error = %v, want ErrUnsafeFile", err)
+	}
+}
+
+// TestSafeReadFile_SymlinkedDirectory covers issue #88: a regular file inside
+// a symlinked directory passes a leaf-only Lstat check, but its resolved path
+// escapes the skill root and must be refused.
+func TestSafeReadFile_SymlinkedDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require admin on Windows")
+	}
+
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.md"), []byte("OUT-OF-TREE"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "references")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The leaf is a regular file, so only the resolved-path containment
+	// check can catch the escape.
+	leaked := filepath.Join(root, "references", "secret.md")
+	if _, err := SafeReadFile(root, leaked); !errors.Is(err, ErrUnsafeFile) {
+		t.Errorf("SafeReadFile(file in symlinked dir) error = %v, want ErrUnsafeFile", err)
+	}
+
+	// A symlinked subdirectory that stays inside the root is fine.
+	if err := os.MkdirAll(filepath.Join(root, "assets", "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "assets", "real", "ok.md"), []byte("fine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "assets", "real"), filepath.Join(root, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SafeReadFile(root, filepath.Join(root, "alias", "ok.md")); err != nil {
+		t.Errorf("SafeReadFile(file in in-tree symlinked dir) error = %v, want nil", err)
+	}
+}
+
+func TestResolvesWithin(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "references")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inside, err := ResolvesWithin(root, sub)
+	if err != nil || !inside {
+		t.Errorf("ResolvesWithin(root, root/references) = %v, %v; want true, nil", inside, err)
+	}
+	inside, err = ResolvesWithin(root, root)
+	if err != nil || !inside {
+		t.Errorf("ResolvesWithin(root, root) = %v, %v; want true, nil", inside, err)
+	}
+	outside := t.TempDir()
+	inside, err = ResolvesWithin(root, outside)
+	if err != nil || inside {
+		t.Errorf("ResolvesWithin(root, outside) = %v, %v; want false, nil", inside, err)
 	}
 }


### PR DESCRIPTION
## What this PR does

Fixes #86 and #88 with a shared mechanism: resolution-based containment. The skill root and each candidate path are resolved with `filepath.EvalSymlinks`, and the resolved path must remain inside the resolved root.

- **#88**: `util.SafeReadFile` now takes the skill root and adds a resolved-path containment check on top of the existing leaf `Lstat` check. A symlinked directory (e.g. `references/` pointing outside the skill tree) no longer exposes out-of-tree regular files to reads, so that content cannot be shipped to the LLM judge. The signature change is safe: `SafeReadFile` was introduced after v1.5.5 and has not appeared in any release.
- **#86**: `CheckInternalLinks` previously verified containment syntactically and then called `os.Stat`, which follows symlinks. It now resolves the target and reports `internal link escapes skill directory: <link> (resolves outside the skill package)` as an error. Symlinks that resolve within the package still pass link validation.

File symlinks remain unread everywhere (the #78 rule is unchanged); this PR only tightens.

## How to test

Verified end-to-end with a hostile fixture (a skill whose `references/` is a symlink to an outside directory and whose SKILL.md links to a file within it): the link is reported as escaping and the read is refused. Also:

- `go test -race ./... -count=1`
- New tests: symlinked-directory read refusal and in-tree symlinked-directory acceptance (`util`), escaping and in-tree symlink link targets (`structure`), symlinked `references/` never reaching judge inputs (`skillcheck`)

## Checklist

- [x] Tests pass locally (`go test -race ./... -count=1`)
- [x] Lint passes locally (`golangci-lint run`)
- [x] New functionality includes tests
- [ ] Breaking changes are noted above (if any)